### PR TITLE
feat: method to count all paths from pkg to root

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -72,6 +72,7 @@ export interface DepGraph {
   getPkgs(): PkgInfo[];
   toJSON(): DepGraphData;
   pkgPathsToRoot(pkg: Pkg): PkgInfo[][];
+  countPathsToRoot(pkg: Pkg): number;
 }
 
 // NOTE/TODO(shaun): deferring any/all design decisions here

--- a/test/core/create-from-json.test.ts
+++ b/test/core/create-from-json.test.ts
@@ -31,12 +31,16 @@ describe('fromJSON simple', () => {
 
   test('getPathsToRoot', async () => {
     expect(graph.pkgPathsToRoot({ name: 'd', version: '0.0.1' })).toHaveLength(1);
+    expect(graph.countPathsToRoot({ name: 'd', version: '0.0.1' })).toBe(1);
 
     expect(graph.pkgPathsToRoot({ name: 'd', version: '0.0.2' })).toHaveLength(1);
+    expect(graph.countPathsToRoot({ name: 'd', version: '0.0.2' })).toBe(1);
 
     expect(graph.pkgPathsToRoot({ name: 'c', version: '1.0.0' })).toHaveLength(2);
+    expect(graph.countPathsToRoot({ name: 'c', version: '1.0.0' })).toBe(2);
 
     expect(graph.pkgPathsToRoot({ name: 'e', version: '5.0.0' })).toHaveLength(2);
+    expect(graph.countPathsToRoot({ name: 'e', version: '5.0.0' })).toBe(2);
 
     expect(graph.pkgPathsToRoot({ name: 'e', version: '5.0.0' })).toEqual([
       [
@@ -135,6 +139,7 @@ test('fromJSON a pkg and a node share same id', async () => {
     { name: 'foo', version: '2' },
     { name: 'toor', version: '1.0.0' },
   ]]);
+  expect(depGraph.countPathsToRoot({ name: 'foo', version: '2' })).toBe(1);
 });
 
 test('fromJSON no deps', async () => {

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -67,12 +67,16 @@ describe('createFromDepTree simple dysmorphic', () => {
 
   test('getPathsToRoot', async () => {
     expect(depGraph.pkgPathsToRoot({ name: 'd', version: '0.0.1' })).toHaveLength(1);
+    expect(depGraph.countPathsToRoot({ name: 'd', version: '0.0.1' })).toBe(1);
 
     expect(depGraph.pkgPathsToRoot({ name: 'd', version: '0.0.2' })).toHaveLength(1);
+    expect(depGraph.countPathsToRoot({ name: 'd', version: '0.0.2' })).toBe(1);
 
     expect(depGraph.pkgPathsToRoot({ name: 'c', version: '1.0.0' })).toHaveLength(2);
+    expect(depGraph.countPathsToRoot({ name: 'c', version: '1.0.0' })).toBe(2);
 
     expect(depGraph.pkgPathsToRoot({ name: 'e', version: '5.0.0' })).toHaveLength(2);
+    expect(depGraph.countPathsToRoot({ name: 'e', version: '5.0.0' })).toBe(2);
 
     expect(depGraph.pkgPathsToRoot({ name: 'e', version: '5.0.0' })).toEqual([
       [
@@ -141,7 +145,7 @@ describe('createFromDepTree goof', () => {
   const depTree = helpers.loadFixture('goof-dep-tree.json');
   const expectedGraph = helpers.loadFixture('goof-graph.json');
 
-  let depGraph;
+  let depGraph: types.DepGraph;
   test('create', async () => {
     depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'npm');
 
@@ -152,17 +156,31 @@ describe('createFromDepTree goof', () => {
     const depGraphInternal = depGraph as types.DepGraphInternal;
 
     const stripAnsiPkg = {name: 'strip-ansi', version: '3.0.1'};
-    const stripAnsiNodes = depGraph.getPkgNodeIds(stripAnsiPkg);
+    const stripAnsiNodes = depGraphInternal.getPkgNodeIds(stripAnsiPkg);
     expect(stripAnsiNodes).toHaveLength(2);
 
     const stripAnsiPaths = depGraph.pkgPathsToRoot(stripAnsiPkg);
     expect(stripAnsiPaths).toHaveLength(6);
+    expect(depGraph.countPathsToRoot(stripAnsiPkg)).toBe(6);
 
     expect(depGraph.pkgPathsToRoot({name: 'ansi-regex', version: '2.0.0'})).toHaveLength(4);
+    expect(depGraph.countPathsToRoot({name: 'ansi-regex', version: '2.0.0'})).toBe(4);
     expect(depGraph.pkgPathsToRoot({name: 'ansi-regex', version: '2.1.1'})).toHaveLength(3);
+    expect(depGraph.countPathsToRoot({name: 'ansi-regex', version: '2.1.1'})).toBe(3);
+    expect(depGraph.pkgPathsToRoot({name: 'wrappy', version: '1.0.2'})).toHaveLength(22);
+    expect(depGraph.countPathsToRoot({name: 'wrappy', version: '1.0.2'})).toBe(22);
 
     const expressNodes = depGraphInternal.getPkgNodeIds({name: 'express', version: '4.12.4'});
     expect(expressNodes).toHaveLength(1);
+  });
+
+  test('count paths to root', async () => {
+    for (const pkg of depGraph.getPkgs()) {
+      const firstResult = depGraph.countPathsToRoot(pkg);
+      const secondResult = depGraph.countPathsToRoot(pkg);
+      expect(secondResult).toEqual(firstResult);
+      expect(secondResult).toEqual(depGraph.pkgPathsToRoot(pkg).length);
+    }
   });
 
   test('compare to expected fixture', async () => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

This adds a new `.countPathsToRoot(pkg: Pkg)` method to the `DepGraph` interface.

This can be useful, to count the number the paths, before generating too many via the `.pkgPathsToRoot()` method.

still not so sure about the method name 🤔 



