### PR TITLE
fix: same TypeScript type for .version in Pkg & PkgInfo

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,12 +5,12 @@
 
 export interface Pkg {
   name: string;
-  version?: string; // shouldn't be null, but might happen
+  version?: string;
 }
 
 export interface PkgInfo {
   name: string;
-  version: string | null;
+  version?: string;
   // NOTE: consider adding in the future
   // requires?: {
   //   name: string;


### PR DESCRIPTION
this simplifies the use for the consumers of the lib, when in example
someone wants to cast from `PkgInfo` to `Pkg`
