### PR TITLE
fix: tree-to-graph: miss-handling of versions containing a '|' char

### DIFF
--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -122,9 +122,9 @@ async function shortenNodeIds(depGraph: types.DepGraphInternal): Promise<types.D
 
       let newNodeId: string;
       if (nodeIds.length === 1) {
-        newNodeId = `${nodeId.split('|')[0]}`;
+        newNodeId = `${trimAfterLastSep(nodeId, '|')}`;
       } else {
-        newNodeId = `${nodeId.split('|')[0]}|${i + 1}`;
+        newNodeId = `${trimAfterLastSep(nodeId, '|')}|${i + 1}`;
       }
 
       nodesMap[nodeId] = newNodeId;
@@ -153,4 +153,8 @@ async function shortenNodeIds(depGraph: types.DepGraphInternal): Promise<types.D
 
 async function spinTheEventLoop() {
   return new Promise((resolve) => setImmediate(resolve));
+}
+
+function trimAfterLastSep(str: string, sep: string) {
+  return str.slice(0, str.lastIndexOf(sep));
 }

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -193,3 +193,36 @@ describe('createFromDepTree with pkg that that misses a version', () => {
     expect(depGraphInternal.getPkgNodeIds({name: 'bar'} as any)).toEqual(['bar@']);
   });
 });
+
+describe('createFromDepTree with funky pipes in the version', () => {
+  const depTree = {
+    name: 'oak',
+    version: '1.0',
+    dependencies: {
+      foo: {
+        version: '2|3',
+      },
+      bar: {
+        version: '1',
+        dependencies: {
+          foo: {
+            version: '2|4',
+          },
+        },
+      },
+    },
+  };
+
+  let depGraph: types.DepGraph;
+  test('create', async () => {
+    depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'composer');
+    expect(depGraph.getPkgs()).toHaveLength(4);
+  });
+
+  test('convert to JSON and back', async () => {
+    const graphJson = depGraph.toJSON();
+    const restoredGraph = await depGraphLib.createFromJSON(graphJson);
+
+    expect(restoredGraph.getPkgs().sort()).toEqual(depGraph.getPkgs().sort());
+  });
+});


### PR DESCRIPTION
When creating from a tree that contains same pkg with different versions
which share a `<prefix>|`, it would have created an invalid graph, due
to uncareful split by `|`.
