### PR TITLE
fix: drop validation for root pkg having only a single node

### DIFF
--- a/src/core/validate-graph.ts
+++ b/src/core/validate-graph.ts
@@ -26,8 +26,4 @@ export function validateGraph(graph: graphlib.Graph,
     .filter((pkgId) => !pkgNodes[pkgId] || pkgNodes[pkgId].size === 0);
   assert(pkgsWithoutInstances.length === 0,
     'not all pkgs have instance nodes');
-
-  const rootPkgId = graph.node(rootNodeId).pkgId;
-  assert(pkgNodes[rootPkgId].size === 1,
-    'root pkg should have exactly one instance node');
 }

--- a/test/core/create-from-json.test.ts
+++ b/test/core/create-from-json.test.ts
@@ -607,9 +607,12 @@ test('fromJSON root has several instances', async () => {
     },
   };
 
-  const go = () => depGraphLib.createFromJSON(graphJson);
-  expect(go).toThrow(/root/);
-  expect(go).toThrow(depGraphLib.Errors.ValidationError);
+  const depGraph = depGraphLib.createFromJSON(graphJson);
+  expect(depGraph.getPkgs().sort()).toEqual([
+    {name: 'toor', version: '1.0.0'},
+    {name: 'foo', version: '2'},
+  ].sort());
+  expect(depGraph.countPathsToRoot({name: 'toor', version: '1.0.0'})).toBe(2);
 });
 
 test('fromJSON a pkg missing info field', async () => {


### PR DESCRIPTION
this can actually happen in npm, and doesn't break currently exposed methods

