### PR TITLE
fix: depTreeToGraph - skip invalid null dependencies

### DIFF
--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -61,8 +61,9 @@ async function buildGraph(
   const hash = crypto.createHash('sha1');
 
   const deps = depTree.dependencies || {};
-  const depNames = _.keys(deps).sort();
-  for (const depName of depNames) {
+  // filter-out invalid null deps (shouldn't happen - but did...)
+  const depNames = _.keys(deps).filter((d) => !!deps[d]);
+  for (const depName of depNames.sort()) {
     const dep = deps[depName];
 
     const subtreeHash = await buildGraph(builder, dep, depName);

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -289,3 +289,29 @@ describe('depTreeToGraph cycle with root', () => {
     expect(restoredGraph.getPkgs().sort()).toEqual(depGraph.getPkgs().sort());
   });
 });
+
+describe('depTreeToGraph with (invalid) null dependency', () => {
+  const depTree = {
+    name: 'pine',
+    version: '4',
+    dependencies: {
+      foo: {
+        version: '1',
+      },
+      bar: null,
+      baz: {
+        version: '3',
+      },
+    },
+  };
+
+  let depGraph: types.DepGraph;
+  test('create', async () => {
+    depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'composer');
+    expect(_.sortBy(depGraph.getPkgs(), 'name')).toEqual(_.sortBy([
+      {name: 'pine', version: '4'},
+      {name: 'foo', version: '1'},
+      {name: 'baz', version: '3'},
+    ], 'name'));
+  });
+});


### PR DESCRIPTION
This shouldn't happen - but did and can due to bugs in the various sources that build the dep-trees, and it's better to just skip a `null` dependency rather than failing completely 