### PR TITLE
feat: graphToDepTree sets .type to pkgManager.name

### DIFF
--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -18,6 +18,7 @@ interface DepTreeDep {
 }
 
 interface DepTree extends DepTreeDep {
+  type?: string;
   packageFormatVersion?: string;
   targetOS?: {
     name: string;
@@ -164,6 +165,7 @@ async function graphToDepTree(depGraphInterface: types.DepGraph, pkgType: string
 
   const depTree = await buildSubtree(depGraph, depGraph.rootNodeId);
 
+  depTree.type = depGraph.pkgManager.name;
   depTree.packageFormatVersion = constructPackageFormatVersion(pkgType);
 
   const targetOS = constructTargetOS(depGraph);

--- a/test/legacy/to-dep-tree.test.ts
+++ b/test/legacy/to-dep-tree.test.ts
@@ -80,6 +80,9 @@ describe('dep-trees survive serialisation through dep-graphs', () => {
       const outputGraph = depGraphLib.createFromJSON(outputJSON);
       const outputTree = await depGraphLib.legacy.graphToDepTree(outputGraph, fixture.pkgType);
 
+      expect(outputTree.type).toEqual(fixture.pkgManagerName);
+      delete outputTree.type;
+
       expect(outputTree).toEqual(inputTree);
     });
   }
@@ -95,6 +98,8 @@ test('graphToDepTree simple dysmorphic', async () => {
   const expectedDepTree = helpers.loadFixture('simple-dep-tree.json');
 
   const depTree = await depGraphLib.legacy.graphToDepTree(depGraph, 'maven');
+  expect(depTree.type).toEqual('maven');
+  delete depTree.type;
   expect(depTree).toEqual(expectedDepTree);
 });
 
@@ -105,6 +110,9 @@ describe('graphToDepTree with a linux pkgManager', () => {
     const expectedDepTree = helpers.loadFixture('os-deb-dep-tree.json');
 
     const depTree = await depGraphLib.legacy.graphToDepTree(depGraph, 'deb');
+
+    expect(depTree.type).toEqual('deb');
+    delete depTree.type;
     expect(depTree).toEqual(expectedDepTree);
   });
 


### PR DESCRIPTION
to maintain backwards compatibility with Rubygems trees that were
assumed to have the `.type` field, and with some other legacy parts that
used to set `.type` with the name of the package-manager
