### PR TITLE
fix: EventLoopSpinner for less setImmediate yields

### DIFF
--- a/src/legacy/event-loop-spinner.ts
+++ b/src/legacy/event-loop-spinner.ts
@@ -1,0 +1,16 @@
+export class EventLoopSpinner {
+  private lastSpin: number;
+
+  constructor(private thresholdMs: number = 10) {
+    this.lastSpin = Date.now();
+  }
+
+  public isStarving(): boolean {
+    return (Date.now() - this.lastSpin) > this.thresholdMs;
+  }
+
+  public async spin() {
+    this.lastSpin = Date.now();
+    return new Promise((resolve) => setImmediate(resolve));
+  }
+}


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

To not block the event-loop in potential blocking functions like the ones converting to and from the legacy dep-tree, we yield to the event-loop via `setImmediate()` during loops/recursions. 
This PR improves this to make sure we don't yield too much, by checking that at-lest 50ms passed since previous `setImmediate()`.