### PR TITLE
feat: Introducing dockerLayerId field to PkgInfo

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,6 +11,7 @@ export interface Pkg {
 export interface PkgInfo {
   name: string;
   version?: string;
+  dockerLayerId?: string;
   // NOTE: consider adding in the future
   // requires?: {
   //   name: string;


### PR DESCRIPTION
This field will be used to determine in which layer a package
in a Docker project was introduced in.

Its immediate usage will be to help displaying in which
Dockerfile layer command a vuln was introduced in.

- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team