### PR TITLE
feat: Introducing labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ export interface DepGraphData {
           property?: {
             name: string;
           };
+        },
+        labels?: {
+          [key: string]: string;
         };
       };
       deps: Array<{

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -12,7 +12,7 @@ interface Node {
 }
 
 class DepGraphImpl implements types.DepGraphInternal {
-  public static SCHEMA_VERSION = '1.1.0';
+  public static SCHEMA_VERSION = '1.2.0';
 
   public static getPkgId(pkg: types.Pkg): string {
     return `${pkg.name}@${pkg.version || ''}`;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -41,6 +41,9 @@ export interface VersionProvenance {
 
 export interface NodeInfo {
   versionProvenance?: VersionProvenance;
+  labels?: {
+    [key: string]: string;
+  };
 }
 
 export interface GraphNode {

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -19,6 +19,9 @@ interface DepTreeDep {
   dependencies?: {
     [depName: string]: DepTreeDep,
   };
+  labels?: {
+    [key: string]: string;
+  };
 }
 
 interface DepTree extends DepTreeDep {
@@ -75,6 +78,9 @@ async function buildGraph(
   if (depTree.versionProvenance) {
     hash.update(objectHash(depTree.versionProvenance));
   }
+  if (depTree.labels) {
+    hash.update(objectHash(depTree.labels));
+  }
 
   const deps = depTree.dependencies || {};
   // filter-out invalid null deps (shouldn't happen - but did...)
@@ -84,7 +90,7 @@ async function buildGraph(
 
     const subtreeHash = await buildGraph(builder, dep, depName, eventLoopSpinner);
 
-    const depPkg = {
+    const depPkg: types.PkgInfo = {
       name: depName,
       version: dep.version,
     };
@@ -97,6 +103,9 @@ async function buildGraph(
 
     if (dep.versionProvenance) {
       nodeInfo.versionProvenance = dep.versionProvenance;
+    }
+    if (dep.labels) {
+      nodeInfo.labels = dep.labels;
     }
 
     builder.addPkgNode(depPkg, depNodeId, nodeInfo);
@@ -121,6 +130,9 @@ async function buildGraph(
 
     if (depTree.versionProvenance) {
       nodeInfo.versionProvenance = depTree.versionProvenance;
+    }
+    if (depTree.labels) {
+      nodeInfo.labels = depTree.labels;
     }
 
     builder.addPkgNode(pkg, pkgNodeId, nodeInfo);
@@ -241,6 +253,9 @@ async function buildSubtree(
   depTree.version = nodePkg.version;
   if (nodeInfo.versionProvenance) {
     depTree.versionProvenance = nodeInfo.versionProvenance;
+  }
+  if (nodeInfo.labels) {
+    depTree.labels = nodeInfo.labels;
   }
 
   const depInstanceIds = depGraph.getNodeDepsNodeIds(nodeId);

--- a/test/fixtures/cyclic-dep-graph.json
+++ b/test/fixtures/cyclic-dep-graph.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "1.2.0",
   "pkgManager": {
     "name": "pip"
   },

--- a/test/fixtures/goof-graph.json
+++ b/test/fixtures/goof-graph.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "1.2.0",
   "pkgManager": {
     "name": "npm"
   },

--- a/test/fixtures/labelled-dep-tree.json
+++ b/test/fixtures/labelled-dep-tree.json
@@ -1,0 +1,63 @@
+{
+  "name": "root",
+  "version": "0.0.0",
+  "packageFormatVersion": "mvn:0.0.1",
+  "dependencies": {
+    "a": {
+      "name": "a",
+      "version": "1.0.0",
+      "dependencies": {
+        "c": {
+          "name": "c",
+          "version": "1.0.0",
+          "dependencies": {
+            "d": {
+              "name": "d",
+              "version": "2.0.0",
+              "labels": {
+                "key": "value1"
+              },
+              "dependencies": {
+                "e": {
+                  "name": "e",
+                  "version": "5.0.0",
+                  "labels": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "b": {
+      "name": "b",
+      "version": "1.0.0",
+      "dependencies": {
+        "c": {
+          "name": "c",
+          "version": "1.0.0",
+          "dependencies": {
+            "d": {
+              "name": "d",
+              "version": "2.0.0",
+              "labels": {
+                "key": "value2"
+              },
+              "dependencies": {
+                "e": {
+                  "name": "e",
+                  "version": "5.0.0",
+                  "labels": {
+                    "key": "value"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/labelled-graph.json
+++ b/test/fixtures/labelled-graph.json
@@ -1,0 +1,141 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "maven"
+  },
+  "pkgs": [
+    {
+      "id": "root@0.0.0",
+      "info": {
+        "name": "root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "e@5.0.0",
+      "info": {
+        "name": "e",
+        "version": "5.0.0"
+      }
+    },
+    {
+      "id": "d@2.0.0",
+      "info": {
+        "name": "d",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "c@1.0.0",
+      "info": {
+        "name": "c",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "a@1.0.0",
+      "info": {
+        "name": "a",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "b@1.0.0",
+      "info": {
+        "name": "b",
+        "version": "1.0.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "a@1.0.0"
+          },
+          {
+            "nodeId": "b@1.0.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "e@5.0.0",
+        "pkgId": "e@5.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "key": "value"
+          }
+        }
+      },
+      {
+        "nodeId": "d@2.0.0|1",
+        "pkgId": "d@2.0.0",
+        "deps": [
+          {
+            "nodeId": "e@5.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "key": "value1"
+          }
+        }
+      },
+      {
+        "nodeId": "d@2.0.0|2",
+        "pkgId": "d@2.0.0",
+        "deps": [
+          {
+            "nodeId": "e@5.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "key": "value2"
+          }
+        }
+      },
+      {
+        "nodeId": "c@1.0.0|1",
+        "pkgId": "c@1.0.0",
+        "deps": [
+          {
+            "nodeId": "d@2.0.0|1"
+          }
+        ]
+      },
+      {
+        "nodeId": "c@1.0.0|2",
+        "pkgId": "c@1.0.0",
+        "deps": [
+          {
+            "nodeId": "d@2.0.0|2"
+          }
+        ]
+      },
+      {
+        "nodeId": "a@1.0.0",
+        "pkgId": "a@1.0.0",
+        "deps": [
+          {
+            "nodeId": "c@1.0.0|1"
+          }
+        ]
+      },
+      {
+        "nodeId": "b@1.0.0",
+        "pkgId": "b@1.0.0",
+        "deps": [
+          {
+            "nodeId": "c@1.0.0|2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/os-deb-graph.json
+++ b/test/fixtures/os-deb-graph.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "1.2.0",
   "pkgManager": {
     "name": "deb",
     "repositories": [

--- a/test/fixtures/simple-dep-tree.json
+++ b/test/fixtures/simple-dep-tree.json
@@ -17,7 +17,10 @@
               "dependencies": {
                 "e": {
                   "name": "e",
-                  "version": "5.0.0"
+                  "version": "5.0.0",
+                  "labels": {
+                    "key": "value"
+                  }
                 }
               }
             }
@@ -39,7 +42,10 @@
               "dependencies": {
                 "e": {
                   "name": "e",
-                  "version": "5.0.0"
+                  "version": "5.0.0",
+                  "labels": {
+                    "key": "value"
+                  }
                 }
               }
             }

--- a/test/fixtures/simple-graph.json
+++ b/test/fixtures/simple-graph.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "1.2.0",
   "pkgManager": {
     "name": "maven"
   },
@@ -72,7 +72,12 @@
       {
         "nodeId": "e@5.0.0",
         "pkgId": "e@5.0.0",
-        "deps": []
+        "deps": [],
+        "info": {
+          "labels": {
+            "key": "value"
+          }
+        }
       },
       {
         "nodeId": "d@0.0.1",

--- a/test/legacy/__snapshots__/from-dep-tree.test.ts.snap
+++ b/test/legacy/__snapshots__/from-dep-tree.test.ts.snap
@@ -1,5 +1,149 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snapshots with labels 1`] = `
+Object {
+  "graph": Object {
+    "nodes": Array [
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "a@1.0.0",
+          },
+          Object {
+            "nodeId": "b@1.0.0",
+          },
+        ],
+        "nodeId": "root-node",
+        "pkgId": "root@0.0.0",
+      },
+      Object {
+        "deps": Array [],
+        "info": Object {
+          "labels": Object {
+            "key": "value",
+          },
+        },
+        "nodeId": "e@5.0.0",
+        "pkgId": "e@5.0.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "e@5.0.0",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "key": "value1",
+          },
+        },
+        "nodeId": "d@2.0.0|1",
+        "pkgId": "d@2.0.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "e@5.0.0",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "key": "value2",
+          },
+        },
+        "nodeId": "d@2.0.0|2",
+        "pkgId": "d@2.0.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "d@2.0.0|1",
+          },
+        ],
+        "nodeId": "c@1.0.0|1",
+        "pkgId": "c@1.0.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "d@2.0.0|2",
+          },
+        ],
+        "nodeId": "c@1.0.0|2",
+        "pkgId": "c@1.0.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "c@1.0.0|1",
+          },
+        ],
+        "nodeId": "a@1.0.0",
+        "pkgId": "a@1.0.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "c@1.0.0|2",
+          },
+        ],
+        "nodeId": "b@1.0.0",
+        "pkgId": "b@1.0.0",
+      },
+    ],
+    "rootNodeId": "root-node",
+  },
+  "pkgManager": Object {
+    "name": "maven",
+  },
+  "pkgs": Array [
+    Object {
+      "id": "root@0.0.0",
+      "info": Object {
+        "name": "root",
+        "version": "0.0.0",
+      },
+    },
+    Object {
+      "id": "e@5.0.0",
+      "info": Object {
+        "name": "e",
+        "version": "5.0.0",
+      },
+    },
+    Object {
+      "id": "d@2.0.0",
+      "info": Object {
+        "name": "d",
+        "version": "2.0.0",
+      },
+    },
+    Object {
+      "id": "c@1.0.0",
+      "info": Object {
+        "name": "c",
+        "version": "1.0.0",
+      },
+    },
+    Object {
+      "id": "a@1.0.0",
+      "info": Object {
+        "name": "a",
+        "version": "1.0.0",
+      },
+    },
+    Object {
+      "id": "b@1.0.0",
+      "info": Object {
+        "name": "b",
+        "version": "1.0.0",
+      },
+    },
+  ],
+  "schemaVersion": "1.2.0",
+}
+`;
+
 exports[`snapshots with versionProvenance 1`] = `
 Object {
   "graph": Object {

--- a/test/legacy/__snapshots__/from-dep-tree.test.ts.snap
+++ b/test/legacy/__snapshots__/from-dep-tree.test.ts.snap
@@ -515,7 +515,7 @@ Object {
       },
     },
   ],
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "1.2.0",
 }
 `;
 
@@ -7844,6 +7844,6 @@ Object {
       },
     },
   ],
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "1.2.0",
 }
 `;

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -303,4 +303,10 @@ describe('snapshots', () => {
     const depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'npm');
     expect(depGraph.toJSON()).toMatchSnapshot();
   });
+
+  test('with labels', async () => {
+    const depTree = helpers.loadFixture('labelled-dep-tree.json');
+    const depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'maven');
+    expect(depGraph.toJSON()).toMatchSnapshot();
+  });
 });

--- a/test/legacy/to-dep-tree.test.ts
+++ b/test/legacy/to-dep-tree.test.ts
@@ -75,6 +75,12 @@ describe('dep-trees survive serialisation through dep-graphs', () => {
       pkgManagerName: 'pip',
       pkgType: 'pip',
     },
+    {
+      description: 'dep-tree different labels for same package',
+      path: 'labelled-dep-tree.json',
+      pkgManagerName: 'maven',
+      pkgType: 'maven',
+    },
   ];
 
   // Recursively delete named properties and properties pointing to
@@ -122,6 +128,20 @@ test('graphToDepTree simple dysmorphic', async () => {
   const depGraphData = helpers.loadFixture('simple-graph.json');
   const depGraph = depGraphLib.createFromJSON(depGraphData);
   const expectedDepTree = helpers.loadFixture('simple-dep-tree.json');
+
+  const depTree = await depGraphLib.legacy.graphToDepTree(depGraph, 'maven');
+  expect(depTree.type).toEqual('maven');
+  delete depTree.type;
+  expect(depTree).toEqual(expectedDepTree);
+});
+
+test('graphToDepTree labelled dysmorphic', async () => {
+  // NOTE: this package tree is "dysmorphic"
+  // i.e. it has a package that appears twice in the tree
+  // at the exact same version, but with slightly different labels
+  const depGraphData = helpers.loadFixture('labelled-graph.json');
+  const depGraph = depGraphLib.createFromJSON(depGraphData);
+  const expectedDepTree = helpers.loadFixture('labelled-dep-tree.json');
 
   const depTree = await depGraphLib.legacy.graphToDepTree(depGraph, 'maven');
   expect(depTree.type).toEqual('maven');


### PR DESCRIPTION
docker layer information is the first use case, but surely not latest
where we want to store additional information on the package level.

this commit extends both depTree and pkgGraph to possibly contain
arbitrary key value information for clients to use as they wish.

- [x] Ready for review