### PR TITLE
fix: memoize hasCycles()

### DIFF
--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -31,6 +31,8 @@ class DepGraphImpl implements types.DepGraphInternal {
 
   private _countNodePathsToRootCache: Map<string, number> = new Map();
 
+  private _hasCycles: boolean | undefined;
+
   public constructor(
     graph: graphlib.Graph,
     rootNodeId: string,
@@ -100,7 +102,11 @@ class DepGraphImpl implements types.DepGraphInternal {
   }
 
   public hasCycles(): boolean {
-    return !graphlib.alg.isAcyclic(this._graph);
+    // `isAcyclic` is expensive, so memoize
+    if (this._hasCycles === undefined) {
+      this._hasCycles = !graphlib.alg.isAcyclic(this._graph);
+    }
+    return this._hasCycles;
   }
 
   public pkgPathsToRoot(pkg: types.Pkg): types.PkgInfo[][] {


### PR DESCRIPTION
- [x] Ready for review

#### What does this PR do?

- hasCycles() can be very expensive, so memoize it

#### Where should the reviewer start?

- eyeball it

#### How should this be manually tested?

Something like this on a complex graph should show an order of magnitude improvement in total time:
```js
console.time('calculate complexity');
depGraph
  .getPkgs()
  .map((pkg) => depGraph.countPathsToRoot(pkg))
  .reduce((acc, pathsToRoot) => acc + pathsToRoot, 0);
console.timeEnd('calculate complexity');
```
Using a particularly pathological graph this went from > 60 seconds down to 14 ms.