### PR TITLE
fix: do not yield to spinner until 10ms actually elapsed

### DIFF
--- a/src/legacy/event-loop-spinner.ts
+++ b/src/legacy/event-loop-spinner.ts
@@ -1,16 +1,22 @@
 export class EventLoopSpinner {
-  private lastSpin: number;
+  private afterLastSpin: number;
 
   constructor(private thresholdMs: number = 10) {
-    this.lastSpin = Date.now();
+    this.afterLastSpin = Date.now();
   }
 
   public isStarving(): boolean {
-    return (Date.now() - this.lastSpin) > this.thresholdMs;
+    return (Date.now() - this.afterLastSpin) > this.thresholdMs;
+  }
+
+  public reset() {
+    this.afterLastSpin = Date.now();
   }
 
   public async spin() {
-    this.lastSpin = Date.now();
-    return new Promise((resolve) => setImmediate(resolve));
+    return new Promise((resolve) => setImmediate(() => {
+      this.reset();
+      resolve();
+    }));
   }
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Long-running tasks (like graph conversions) are much slower than they should be. It's possible it happens because the task yields to spinner after 10 ms _since the start of the spin_ have elapsed. We should switch it to 10 ms since the end of spin, to ensure that we have stable 10ms chunks.

