### PR TITLE
fix: add semver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "graphlib": "^2.1.5",
     "lodash": "^4",
     "object-hash": "^1.3.1",
+    "semver": "^6.0.0",
     "source-map-support": "^0.5.11",
     "tslib": "^1.9.3"
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

- we use semver to check the schema version of the graph data but failed to include it as a direct dependency