### PR TITLE
fix: check for valid schema version before checking range

### DIFF
--- a/src/core/create-from-json.ts
+++ b/src/core/create-from-json.ts
@@ -60,7 +60,9 @@ function assert(condition: boolean, msg: string) {
 }
 
 function validateDepGraphData(depGraphData: DepGraphData) {
-  assert(semver.satisfies(depGraphData.schemaVersion, SUPPORTED_SCHEMA_RANGE),
+  assert(
+    !!semver.valid(depGraphData.schemaVersion)
+      && semver.satisfies(depGraphData.schemaVersion, SUPPORTED_SCHEMA_RANGE),
     `dep-graph schemaVersion not in "${SUPPORTED_SCHEMA_RANGE}"`);
   assert(depGraphData.pkgManager && !!depGraphData.pkgManager.name, '.pkgManager.name is missing');
 

--- a/test/core/create-from-json.test.ts
+++ b/test/core/create-from-json.test.ts
@@ -199,6 +199,26 @@ test('fromJSON too new schemaVersion', async () => {
   expect(go).toThrow(depGraphLib.Errors.ValidationError);
 });
 
+test('fromJSON no schemaVersion', async () => {
+  const graphJson: depGraphLib.DepGraphData = helpers.loadFixture('simple-graph.json');
+
+  delete graphJson.schemaVersion;
+
+  const go = () => depGraphLib.createFromJSON(graphJson);
+  expect(go).toThrow(/schemaVersion/);
+  expect(go).toThrow(depGraphLib.Errors.ValidationError);
+});
+
+test('fromJSON bad schemaVersion', async () => {
+  const graphJson: depGraphLib.DepGraphData = helpers.loadFixture('simple-graph.json');
+
+  graphJson.schemaVersion = 'foo';
+
+  const go = () => depGraphLib.createFromJSON(graphJson);
+  expect(go).toThrow(/schemaVersion/);
+  expect(go).toThrow(depGraphLib.Errors.ValidationError);
+});
+
 test('fromJSON missing root', async () => {
   const graphJson: depGraphLib.DepGraphData = helpers.loadFixture('simple-graph.json');
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

- check for valid schema version before checking range
- `semver@6.1.0` throws an exception when testing an invalid range
- so pre-check the input to ensure we throw the correct exception