### PR TITLE
fix: make "pruned" a label, to preserve during the conversion to graph

### DIFF
--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -22,9 +22,6 @@ interface DepTreeDep {
   labels?: {
     [key: string]: string;
   };
-
-  // Identical subtree already presents within the deduplication scope (a top-level dependency)
-  pruned?: boolean;
 }
 
 interface DepTree extends DepTreeDep {
@@ -34,6 +31,13 @@ interface DepTree extends DepTreeDep {
     name: string;
     version: string;
   };
+}
+
+function addLabel(dep: DepTreeDep, key: string, value: string) {
+  if (!dep.labels) {
+    dep.labels = {};
+  }
+  dep.labels[key] = value;
 }
 
 async function depTreeToGraph(depTree: DepTree, pkgManagerName: string): Promise<types.DepGraph> {
@@ -288,7 +292,7 @@ async function buildSubtree(
   if (maybeDeduplicationSet) {
     if (maybeDeduplicationSet.has(nodeId)) {
       if (depInstanceIds.length > 0) {
-        depTree.pruned = true;
+        addLabel(depTree, 'pruned', 'true');
       }
       return depTree;
     }

--- a/test/fixtures/pruneable-tree-multi-top-level-deps-pruned.json
+++ b/test/fixtures/pruneable-tree-multi-top-level-deps-pruned.json
@@ -33,7 +33,9 @@
             "c": {
               "name": "c",
               "version": "1.0.0",
-              "pruned": true
+              "labels": {
+                "pruned": "true"
+              }
             }
           }
         }

--- a/test/fixtures/pruneable-tree-pruned.json
+++ b/test/fixtures/pruneable-tree-pruned.json
@@ -33,7 +33,9 @@
             "c": {
               "name": "c",
               "version": "1.0.0",
-              "pruned": true
+              "labels": {
+                "pruned": "true"
+              }
             }
           }
         }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
We need to save "pruned" attribute to display it in the Registry.

Gee, we have exactly the tool for that: labels!
