### PR TITLE
feat: add pruned label to graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ export interface DepGraphData {
         },
         labels?: {
           [key: string]: string | undefined;
-          scope?: 'dev' | 'prod';
         };
       };
       deps: Array<{

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -44,6 +44,7 @@ export interface NodeInfo {
   labels?: {
     [key: string]: string | undefined;
     scope?: 'dev' | 'prod';
+    pruned?: 'cyclic' | 'true';
   };
 }
 

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -22,6 +22,7 @@ interface DepTreeDep {
   labels?: {
     [key: string]: string | undefined;
     scope?: 'dev' | 'prod';
+    pruned?: 'cyclic' | 'true';
   };
 }
 

--- a/test/fixtures/npm-cyclic-dep-tree.json
+++ b/test/fixtures/npm-cyclic-dep-tree.json
@@ -1,0 +1,32 @@
+{
+  "dependencies": {
+    "debug": {
+      "dependencies": {
+        "ms": {
+          "dependencies": {
+            "debug": {
+              "labels": {
+                "scope": "prod",
+                "pruned": "cyclic"
+              },
+              "name": "debug",
+              "version": "2.0.0"
+            }
+          },
+          "labels": {
+            "scope": "prod"
+          },
+          "name": "ms",
+          "version": "0.6.2"
+        }
+      },
+      "labels": {
+        "scope": "prod"
+      },
+      "name": "debug",
+      "version": "2.0.0"
+    }
+  },
+  "name": "trucolor",
+  "version": "0.7.1"
+}

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -265,6 +265,14 @@ describe('depTreeToGraph cycle with root', () => {
   });
 });
 
+describe('depTreeToGraph cycle with labels', () => {
+  test('npm', async () => {
+    const depTree = helpers.loadFixture('npm-cyclic-dep-tree.json');
+    const depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'npm');
+    expect((await depGraphLib.legacy.graphToDepTree(depGraph, 'npm')).dependencies).toEqual(depTree.dependencies);
+  });
+});
+
 describe('depTreeToGraph with (invalid) null dependency', () => {
   const depTree = {
     name: 'pine',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add `pruned` label definition to graph. The three options we set for it are `true` - for pruned in CLI with the --pruned option, `cyclic` - for cyclic deps pruned like in npm, `seen` - if the same subtree was already seen when run with --prune-repeated-dependencies