### PR TITLE
fix: export Pkg & PkgInfo TS types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import 'source-map-support/register';
 
-export { DepGraphData, DepGraph, PkgManager } from './core/types';
+export {
+  DepGraph,
+  DepGraphData,
+  Pkg,
+  PkgInfo,
+  PkgManager,
+} from './core/types';
 export { createFromJSON } from './core/create-from-json';
 export { DepGraphBuilder } from './core/builder';
 

--- a/test/core/builder.test.ts
+++ b/test/core/builder.test.ts
@@ -1,4 +1,4 @@
-import { DepGraphBuilder } from '../../src/core/builder';
+import { DepGraphBuilder } from '../../src';
 
 describe('empty graph', () => {
   const builder = new DepGraphBuilder({name: 'pip'});


### PR DESCRIPTION
export `Pkg` & `PkgInfo` TS types, as they are used in the already exported `DepGraph` type, and are useful to the consumers of the lib
