### PR TITLE
docs: aling DepTree interface with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ A `DepTree` is a recursive structure that is quite similar to the output of `npm
 interface DepTree {
   name: string;
   version: string;
-  dependencies: {
+  dependencies?: {
     [depName: string]: DepTree
   };
 }


### PR DESCRIPTION
Based on  src/legacy/index.ts:19, dependencies is not a mandatory key.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Aligns README with the implementation
