### PR TITLE
fix: avoid stack overflow with spread operator

### DIFF
--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -125,7 +125,10 @@ class DepGraphImpl implements types.DepGraphInternal {
 
     const pathsToRoot: types.PkgInfo[][] = [];
     for (const id of this.getPkgNodeIds(pkg)) {
-      pathsToRoot.push(...this.pathsFromNodeToRoot(id));
+      const paths = this.pathsFromNodeToRoot(id);
+      for (const path of paths) {
+        pathsToRoot.push(path);
+      }
     }
     // note: sorting to get shorter paths first -
     //  it's nicer - and better resembles older behaviour
@@ -281,7 +284,9 @@ class DepGraphImpl implements types.DepGraphInternal {
       const out = this.pathsFromNodeToRoot(id).map((path) => {
         return [this.getNodePkg(nodeId)].concat(path);
       });
-      allPaths.push(...out);
+      for (const path of out) {
+        allPaths.push(path);
+      }
     });
 
     return allPaths;

--- a/test/core/stress.test.ts
+++ b/test/core/stress.test.ts
@@ -1,0 +1,36 @@
+import * as depGraphLib from '../../src';
+
+const dependencyName = 'needle';
+
+async function generateLargeGraph(width: number) {
+  const builder = new depGraphLib.DepGraphBuilder(
+    { name: 'npm' },
+    { name: 'root', version: '1.2.3' },
+  );
+  const rootNodeId = 'root-node';
+
+  const deepDependency = { name: dependencyName, version: '1.2.3' };
+
+  builder.addPkgNode(deepDependency, dependencyName);
+  builder.connectDep(rootNodeId, dependencyName);
+
+  for (let j = 0; j < width; j++) {
+    const shallowName = `id-${j}`;
+    const shallowDependency = { name: shallowName, version: '1.2.3' };
+
+    builder.addPkgNode(shallowDependency, shallowName);
+    builder.connectDep(rootNodeId, shallowName);
+    builder.connectDep(shallowName, dependencyName);
+  }
+
+  return builder.build();
+}
+
+describe('stress tests', () => {
+  test('pkgPathsToRoot() does not cause stack overflow for large dep-graphs', async () => {
+    const graph = await generateLargeGraph(125000);
+
+    const result = graph.pkgPathsToRoot({ name: dependencyName, version: '1.2.3' });
+    expect(result).toBeDefined();
+  });
+});


### PR DESCRIPTION
A customer cannot scan their project with a supposedly very large dependency graph because as soon as it reaches our back-end, we get a stack overflow error. It was identified that the error is due to the combination of Array.push() and the spread operator.

For reference: https://github.com/nodejs/node/issues/16870

To reproduce, create an array of size 2^17 then do [].push(...myArray);.

This fix replaces all uses of push() and spread with a simple loop.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team


#### How should this be manually tested?

```
node
> const example = [];
undefined
> for (let i = 0; i < 2 ** 23; i++) {
...     example.push('o');
... }
8388608
> [].push(...example);
Thrown:
RangeError: Maximum call stack size exceeded
>
```

#### What are the relevant tickets?

[Zendesk Ticket 2194](https://snyk.zendesk.com/agent/tickets/2194)
