### PR TITLE
Feat/expose node info

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ts-jest": "^24",
     "ts-node": "^8",
     "tslint": "^5",
-    "typescript": "^3.3.3333"
+    "typescript": "^3.7.2"
   },
   "dependencies": {
     "graphlib": "^2.1.5",
@@ -45,6 +45,6 @@
     "object-hash": "^1.3.1",
     "semver": "^6.0.0",
     "source-map-support": "^0.5.11",
-    "tslib": "^1.9.3"
+    "tslib": "^1.10.0"
   }
 }

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -7,7 +7,7 @@ export {
   DepGraphImpl,
 };
 
-interface Node {
+interface GraphNode {
   pkgId: string;
   info?: types.NodeInfo;
 }
@@ -48,7 +48,7 @@ class DepGraphImpl implements types.DepGraphInternal {
     this._pkgManager = pkgManager;
 
     this._rootNodeId = rootNodeId;
-    this._rootPkgId = (graph.node(rootNodeId) as Node).pkgId;
+    this._rootPkgId = (graph.node(rootNodeId) as GraphNode).pkgId;
 
     this._pkgList = _.values(pkgs);
     this._depPkgsList = this._pkgList
@@ -73,6 +73,21 @@ class DepGraphImpl implements types.DepGraphInternal {
 
   public getDepPkgs(): types.PkgInfo[] {
     return this._depPkgsList;
+  }
+
+  public getPkgNodes(pkg: types.Pkg): types.Node[] {
+    const pkgId = DepGraphImpl.getPkgId(pkg);
+
+    const nodes: types.Node[] = [];
+    for (const nodeId of Array.from(this._pkgNodes[pkgId])) {
+      const graphNode = this.getGraphNode(nodeId);
+
+      nodes.push({
+        info: graphNode.info || {},
+      });
+    }
+
+    return nodes;
   }
 
   public getNode(nodeId: string): types.NodeInfo {
@@ -171,7 +186,7 @@ class DepGraphImpl implements types.DepGraphInternal {
       const deps = (this._graph.successors(nodeId) || [])
         .map((depNodeId) => ({ nodeId: depNodeId }));
 
-      const node = this._graph.node(nodeId) as Node;
+      const node = this._graph.node(nodeId) as GraphNode;
       const elem: types.GraphNode = {
         nodeId,
         pkgId: node.pkgId,
@@ -265,8 +280,8 @@ class DepGraphImpl implements types.DepGraphInternal {
     return true;
   }
 
-  private getGraphNode(nodeId: string): Node {
-    const node = this._graph.node(nodeId) as Node;
+  private getGraphNode(nodeId: string): GraphNode {
+    const node = this._graph.node(nodeId) as GraphNode;
     if (!node) {
       throw new Error(`no such node: ${nodeId}`);
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,6 +48,12 @@ export interface NodeInfo {
   };
 }
 
+export interface Node {
+  // id: string; - can be added later once it's useful as input to other methods
+  // pkg: PkgInfo; - it can be nice to return this, consider when exposing more node related methods
+  info: NodeInfo;
+}
+
 export interface GraphNode {
   nodeId: string;
   pkgId: string;
@@ -85,6 +91,7 @@ export interface DepGraph {
   readonly rootPkg: PkgInfo;
   getPkgs(): PkgInfo[];
   getDepPkgs(): PkgInfo[];
+  getPkgNodes(pkg: Pkg): Node[];
   toJSON(): DepGraphData;
   pkgPathsToRoot(pkg: Pkg): PkgInfo[][];
   countPathsToRoot(pkg: Pkg): number;

--- a/test/core/create-from-json.test.ts
+++ b/test/core/create-from-json.test.ts
@@ -69,6 +69,17 @@ describe('fromJSON simple', () => {
       ],
     ]);
   });
+
+  test('getPkgNodes', () => {
+    expect(graph.getPkgNodes({ name: 'root', version: '0.0.0' })).toHaveLength(1);
+    expect(graph.getPkgNodes({ name: 'a', version: '1.0.0' })).toHaveLength(1);
+
+    const cNodes = graph.getPkgNodes({ name: 'c', version: '1.0.0' });
+    expect(cNodes).toHaveLength(2);
+    expect(cNodes[0].info).toEqual(cNodes[1].info);
+
+    expect(() => graph.getPkgNodes({ name: 'no-such-pkg', version: '1.3.7'})).toThrow();
+  });
 });
 
 test('fromJSON with pkgManager.repositories', () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -25,6 +25,10 @@ export function depTreesEqual(a: any, b: any) {
     return false;
   }
 
+  if (!_.isEqual(a.labels, b.labels) || !_.isEqual(a.versionProvenance, b.versionProvenance)) {
+    return false;
+  }
+
   const aDeps = a.dependencies || {};
   const bDeps = b.dependencies || {};
 

--- a/test/legacy/__snapshots__/from-dep-tree.test.ts.snap
+++ b/test/legacy/__snapshots__/from-dep-tree.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snapshots with labels 1`] = `
+exports[`with labels matches snapshot 1`] = `
 Object {
   "graph": Object {
     "nodes": Array [
@@ -144,7 +144,7 @@ Object {
 }
 `;
 
-exports[`snapshots with versionProvenance 1`] = `
+exports[`with versionProvenance matches snapshot 1`] = `
 Object {
   "graph": Object {
     "nodes": Array [
@@ -663,7 +663,7 @@ Object {
 }
 `;
 
-exports[`snapshots without versionProvenance 1`] = `
+exports[`without versionProvenance matches snapshot 1`] = `
 Object {
   "graph": Object {
     "nodes": Array [

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -325,14 +325,20 @@ describe('depTreeToGraph with (invalid) null dependency', () => {
 
 describe('with versionProvenance', () => {
   let depGraph: types.DepGraph;
+  let depTree: depGraphLib.legacy.DepTree;
 
   beforeAll(async () => {
-    const depTree = helpers.loadFixture('maven-dep-tree.json');
+    depTree = helpers.loadFixture('maven-dep-tree.json');
     depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'maven');
   });
 
   it('matches snapshot', () => {
     expect(depGraph.toJSON()).toMatchSnapshot();
+  });
+
+  it ('equals orig depTree when converted back', async () => {
+    const restoredDepTree = await depGraphLib.legacy.graphToDepTree(depGraph, 'maven');
+    expect(helpers.depTreesEqual(restoredDepTree, depTree)).toBeTruthy();
   });
 
   it ('getPkgNodes() returns versionProvenance', () => {
@@ -364,14 +370,20 @@ describe('without versionProvenance', () => {
 
 describe('with labels', () => {
   let depGraph: types.DepGraph;
+  let depTree: depGraphLib.legacy.DepTree;
 
   beforeAll(async () => {
-    const depTree = helpers.loadFixture('labelled-dep-tree.json');
+    depTree = helpers.loadFixture('labelled-dep-tree.json');
     depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'maven');
   });
 
   it('matches snapshot', () => {
     expect(depGraph.toJSON()).toMatchSnapshot();
+  });
+
+  it ('equals orig depTree when converted back', async () => {
+    const restoredDepTree = await depGraphLib.legacy.graphToDepTree(depGraph, 'maven');
+    expect(helpers.depTreesEqual(restoredDepTree, depTree)).toBeTruthy();
   });
 
   it('getPkgNodes() returns labels', () => {

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -323,22 +323,61 @@ describe('depTreeToGraph with (invalid) null dependency', () => {
   });
 });
 
-describe('snapshots', () => {
-  test('with versionProvenance', async () => {
+describe('with versionProvenance', () => {
+  let depGraph: types.DepGraph;
+
+  beforeAll(async () => {
     const depTree = helpers.loadFixture('maven-dep-tree.json');
-    const depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'maven');
+    depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'maven');
+  });
+
+  it('matches snapshot', () => {
     expect(depGraph.toJSON()).toMatchSnapshot();
   });
 
-  test('without versionProvenance', async () => {
+  it ('getPkgNodes() returns versionProvenance', () => {
+    const commonsIoNodes = depGraph.getPkgNodes({name: 'commons-io:commons-io', version: '2.2'});
+    expect(commonsIoNodes[0].info.versionProvenance!.type).toEqual('dependencyManagement');
+
+    const ognlNodes = depGraph.getPkgNodes({name: 'ognl:ognl', version: '3.0.6'});
+    expect(ognlNodes[0].info.versionProvenance).toEqual({
+      type: 'property',
+      property: { name: 'ognl.version' },
+      // tslint:disable:max-line-length
+      location: 'https://maven-central.storage-download.googleapis.com/repos/central/data/org/apache/struts/struts2-parent/2.3.20/struts2-parent-2.3.20.pom',
+    });
+  });
+});
+
+describe('without versionProvenance', () => {
+  let depGraph: types.DepGraph;
+
+  beforeAll(async () => {
     const depTree = helpers.loadFixture('goof-dep-tree.json');
-    const depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'npm');
+    depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'npm');
+  });
+
+  it('matches snapshot', () => {
+    expect(depGraph.toJSON()).toMatchSnapshot();
+  });
+});
+
+describe('with labels', () => {
+  let depGraph: types.DepGraph;
+
+  beforeAll(async () => {
+    const depTree = helpers.loadFixture('labelled-dep-tree.json');
+    depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'maven');
+  });
+
+  it('matches snapshot', () => {
     expect(depGraph.toJSON()).toMatchSnapshot();
   });
 
-  test('with labels', async () => {
-    const depTree = helpers.loadFixture('labelled-dep-tree.json');
-    const depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'maven');
-    expect(depGraph.toJSON()).toMatchSnapshot();
+  it('getPkgNodes() returns labels', () => {
+    let dNodes = depGraph.getPkgNodes({name: 'd', version: '2.0.0'});
+    dNodes = _.sortBy(dNodes, 'id');
+    expect(dNodes[0].info.labels).toEqual({key: 'value1'});
+    expect(dNodes[1].info.labels).toEqual({key: 'value2'});
   });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

adds `.getPkgNodes(pkg: Pkg)` method to `DepGraph` that returns a list of nodes that represent the given pkg. This is needed to get access to `NodeInfo` (for now it's labels & version-provenance).
