### PR TITLE
feat: update tests and correct type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,21 @@ export interface DepGraph {
   };
   readonly rootPkg: {
     name: string;
-    version: string | null;
+    version?: string;
   };
   // all unique packages in the graph (including root package)
   getPkgs(): Array<{
     name: string;
-    version: string | null;
+    version?: string;
   }>;
   // all unique packages in the graph, except the root package
   getDepPkgs(): Array<{
     name: string;
-    version: string | null;
+    version?: string;
   }>;
   pkgPathsToRoot(pkg: Pkg): Array<Array<{
     name: string;
-    version: string | null;
+    version?: string;
   }>>;
   countPathsToRoot(pkg: Pkg): number;
   toJSON(): DepGraphData;
@@ -89,7 +89,7 @@ export interface DepGraphData {
     id: string;
     info: {
       name: string;
-      version: string | null;
+      version?: string;
     };
   }>;
   graph: {

--- a/src/core/create-from-json.ts
+++ b/src/core/create-from-json.ts
@@ -22,8 +22,7 @@ export function createFromJSON(depGraphData: DepGraphData): DepGraph {
   const pkgNodes: {[pkgId: string]: Set<string>} = {};
 
   for (const { id, info } of depGraphData.pkgs) {
-    // TODO: avoid this, instead just use `info` as is
-    pkgs[id] = info.version ? info : { ...info, version: null } as any;
+    pkgs[id] = info;
   }
 
   for (const node of depGraphData.graph.nodes) {

--- a/src/core/create-from-json.ts
+++ b/src/core/create-from-json.ts
@@ -22,7 +22,9 @@ export function createFromJSON(depGraphData: DepGraphData): DepGraph {
   const pkgNodes: {[pkgId: string]: Set<string>} = {};
 
   for (const { id, info } of depGraphData.pkgs) {
-    pkgs[id] = info;
+    pkgs[id] = info.version
+      ? info
+      : { ...info, version: undefined };
   }
 
   for (const node of depGraphData.graph.nodes) {

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -161,6 +161,10 @@ class DepGraphImpl implements types.DepGraphInternal {
       otherDepGraph = createFromJSON(other.toJSON()) as types.DepGraphInternal;
     }
 
+    // In theory, for the graphs created by standard means, `_.isEquals(this._data, otherDepGraph._data)`
+    // should suffice, since node IDs will be generated in a predictable way.
+    // However, to support unconventional node IDs, we run our own deep
+    // comparison.
     return this.nodeEquals(this, this.rootNodeId, otherDepGraph, otherDepGraph.rootNodeId, compareRoot);
   }
 

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -163,8 +163,8 @@ class DepGraphImpl implements types.DepGraphInternal {
 
     // In theory, for the graphs created by standard means, `_.isEquals(this._data, otherDepGraph._data)`
     // should suffice, since node IDs will be generated in a predictable way.
-    // However, to support unconventional node IDs, we run our own deep
-    // comparison.
+    // However, there might be different versions of graph and inconsistencies
+    // in the ordering of the arrays, so we perform a deep comparison.
     return this.nodeEquals(this, this.rootNodeId, otherDepGraph, otherDepGraph.rootNodeId, compareRoot);
   }
 

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -45,7 +45,7 @@ function addLabel(dep: DepTreeDep, key: string, value: string) {
 async function depTreeToGraph(depTree: DepTree, pkgManagerName: string): Promise<types.DepGraph> {
   const rootPkg = {
     name: depTree.name!,
-    version: depTree.version,
+    version: depTree.version || undefined,
   };
 
   const pkgManagerInfo: types.PkgManager = {

--- a/test/core/create-from-json.test.ts
+++ b/test/core/create-from-json.test.ts
@@ -759,10 +759,10 @@ test('fromJSON a pkg missing version field', () => {
   const depGraph = depGraphLib.createFromJSON(graphJson as any);
   expect(depGraph.getPkgs().sort()).toEqual([
     { name: 'toor', version: '1.0.0' },
-    { name: 'foo', version: null },
+    { name: 'foo' },
   ]);
   expect(depGraph.getDepPkgs().sort()).toEqual([
-    { name: 'foo', version: null },
+    { name: 'foo' },
   ]);
 });
 

--- a/test/core/create-from-json.test.ts
+++ b/test/core/create-from-json.test.ts
@@ -17,7 +17,7 @@ describe('fromJSON simple', () => {
   });
 
   test('getPkgs()', () => {
-    expect(graph.getPkgs().sort(helpers.depSort)).toEqual([
+    helpers.expectSamePkgs(graph.getPkgs(), [
       { name: 'a', version: '1.0.0' },
       { name: 'b', version: '1.0.0' },
       { name: 'c', version: '1.0.0' },
@@ -25,18 +25,18 @@ describe('fromJSON simple', () => {
       { name: 'd', version: '0.0.2' },
       { name: 'e', version: '5.0.0' },
       { name: 'root', version: '0.0.0' },
-    ].sort(helpers.depSort));
+    ]);
   });
 
   test('getDepPkgs()', () => {
-    expect(graph.getDepPkgs().sort(helpers.depSort)).toEqual([
+    helpers.expectSamePkgs(graph.getDepPkgs(), [
       { name: 'a', version: '1.0.0' },
       { name: 'b', version: '1.0.0' },
       { name: 'c', version: '1.0.0' },
       { name: 'd', version: '0.0.1' },
       { name: 'd', version: '0.0.2' },
       { name: 'e', version: '5.0.0' },
-    ].sort(helpers.depSort));
+    ]);
   });
 
   test('getPathsToRoot', () => {
@@ -140,11 +140,11 @@ test('fromJSON a pkg and a node share same id', () => {
 
   const depGraph = depGraphLib.createFromJSON(graphJson);
 
-  expect(depGraph.getPkgs().sort()).toEqual([
+  helpers.expectSamePkgs(depGraph.getPkgs(), [
     { name: 'toor', version: '1.0.0' },
     { name: 'foo', version: '2' },
   ].sort());
-  expect(depGraph.getDepPkgs()).toEqual([
+  helpers.expectSamePkgs(depGraph.getDepPkgs(), [
     { name: 'foo', version: '2' },
   ]);
 
@@ -352,13 +352,13 @@ test('fromJSON with a cycle', () => {
 
   const depGraph = depGraphLib.createFromJSON(graphJson);
 
-  expect(depGraph.getPkgs().sort()).toEqual([
+  helpers.expectSamePkgs(depGraph.getPkgs(), [
     { name: 'toor', version: '1.0.0' },
     { name: 'foo', version: '2' },
     { name: 'bar', version: '3' },
     { name: 'baz', version: '4' },
   ]);
-  expect(depGraph.getDepPkgs().sort()).toEqual([
+  helpers.expectSamePkgs(depGraph.getDepPkgs(), [
     { name: 'foo', version: '2' },
     { name: 'bar', version: '3' },
     { name: 'baz', version: '4' },
@@ -648,11 +648,11 @@ test('fromJSON root has several instances', () => {
   };
 
   const depGraph = depGraphLib.createFromJSON(graphJson);
-  expect(depGraph.getPkgs().sort()).toEqual([
+  helpers.expectSamePkgs(depGraph.getPkgs(), [
     {name: 'toor', version: '1.0.0'},
     {name: 'foo', version: '2'},
   ].sort());
-  expect(depGraph.getDepPkgs().sort()).toEqual([
+  helpers.expectSamePkgs(depGraph.getDepPkgs(), [
     {name: 'foo', version: '2'},
   ].sort());
   expect(depGraph.countPathsToRoot({name: 'toor', version: '1.0.0'})).toBe(2);
@@ -757,11 +757,11 @@ test('fromJSON a pkg missing version field', () => {
   };
 
   const depGraph = depGraphLib.createFromJSON(graphJson as any);
-  expect(depGraph.getPkgs().sort()).toEqual([
+  helpers.expectSamePkgs(depGraph.getPkgs(), [
     { name: 'toor', version: '1.0.0' },
     { name: 'foo' },
   ]);
-  expect(depGraph.getDepPkgs().sort()).toEqual([
+  helpers.expectSamePkgs(depGraph.getDepPkgs(), [
     { name: 'foo' },
   ]);
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,12 +1,13 @@
 import * as _ from 'lodash';
 import * as fs from 'fs';
 import * as path from 'path';
+import { PkgInfo } from '../src';
 
 export function loadFixture(name: string) {
   return JSON.parse(fs.readFileSync(path.join(__dirname, `fixtures/${name}`), 'utf8'));
 }
 
-export function depSort(a: any, b: any) {
+function depSort(a: any, b: any) {
   if (a.name < b.name) {
     return -1;
   } else if (a.name > b.name) {
@@ -18,6 +19,10 @@ export function depSort(a: any, b: any) {
     return 1;
   }
   return 0;
+}
+
+export function expectSamePkgs(actual: PkgInfo[], expected: PkgInfo[]) {
+  return expect(actual.sort(depSort)).toEqual(expected.sort(depSort));
 }
 
 export function depTreesEqual(a: any, b: any) {

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -29,7 +29,7 @@ describe('depTreeToGraph simple dysmorphic', () => {
   });
 
   test('getPkgs', async () => {
-    expect(depGraph.getPkgs().sort(helpers.depSort)).toEqual([
+    helpers.expectSamePkgs(depGraph.getPkgs(), [
       { name: 'a', version: '1.0.0' },
       { name: 'b', version: '1.0.0' },
       { name: 'c', version: '1.0.0' },
@@ -37,15 +37,15 @@ describe('depTreeToGraph simple dysmorphic', () => {
       { name: 'd', version: '0.0.2' },
       { name: 'e', version: '5.0.0' },
       { name: 'root', version: '0.0.0' },
-    ].sort(helpers.depSort));
-    expect(depGraph.getDepPkgs().sort(helpers.depSort)).toEqual([
+    ]);
+    helpers.expectSamePkgs(depGraph.getDepPkgs(), [
       { name: 'a', version: '1.0.0' },
       { name: 'b', version: '1.0.0' },
       { name: 'c', version: '1.0.0' },
       { name: 'd', version: '0.0.1' },
       { name: 'd', version: '0.0.2' },
       { name: 'e', version: '5.0.0' },
-    ].sort(helpers.depSort));
+    ]);
   });
 
   test('getPathsToRoot', async () => {
@@ -228,8 +228,8 @@ describe('depTreeToGraph with funky pipes in the version', () => {
     const graphJson = depGraph.toJSON();
     const restoredGraph = await depGraphLib.createFromJSON(graphJson);
 
-    expect(restoredGraph.getPkgs().sort()).toEqual(depGraph.getPkgs().sort());
-    expect(restoredGraph.getDepPkgs().sort()).toEqual(depGraph.getDepPkgs().sort());
+    helpers.expectSamePkgs(restoredGraph.getPkgs(), depGraph.getPkgs());
+    helpers.expectSamePkgs(restoredGraph.getDepPkgs(), depGraph.getDepPkgs());
   });
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Corrects two mistakes:

* some tests were using `.sort()` on a `PkgInfo[]` list. Without the comparison function, this sort was doing nothing. The tests were passing just by accident.
* `PkgInfo.version` was set to `null` sometimes and was advertised as `null`-able in the README. This was fixed, now only `undefined` should be used.

Since it introduces a light breakage (correction) of the library interface, this is being submitted as "feat" rather than "fix" or "tests".