### PR TITLE
Feat: handle cycles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 coverage/
 package-lock.json
+.idea/

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -108,5 +108,4 @@ export interface DepGraphInternal extends DepGraph {
   getPkgNodeIds(pkg: Pkg): string[];
   getNodeDepsNodeIds(nodeId: string): string[];
   getNodeParentsNodeIds(nodeId: string): string[];
-  hasCycles(): boolean;
 }

--- a/test/core/create-from-json.test.ts
+++ b/test/core/create-from-json.test.ts
@@ -391,11 +391,24 @@ test('fromJSON with a cycle', () => {
     { name: 'baz', version: '4' },
   ]);
 
-  // const convertToDepTree = () => depGraphLib.legacy.graphToDepTree(depGraph);
-  // expect(convertToDepTree()).rejects.toThrow(/cycl/);
+  const barPathsToRoot = depGraph.pkgPathsToRoot({ name: 'bar', version: '3' });
+  expect(barPathsToRoot).toEqual([
+    [
+      { name: 'bar', version: '3' },
+      { name: 'foo', version: '2' },
+      { name: 'toor', version: '1.0.0' },
+    ],
+  ]);
+  expect(depGraph.countPathsToRoot({ name: 'bar', version: '3' })).toBe(1);
 
-  const getPaths = () => depGraph.pkgPathsToRoot({ name: 'bar', version: '2' });
-  expect(getPaths).toThrow(/cycl/);
+  const fooPathsToRoot = depGraph.pkgPathsToRoot({ name: 'foo', version: '2' });
+  expect(fooPathsToRoot).toEqual([
+    [
+      { name: 'foo', version: '2' },
+      { name: 'toor', version: '1.0.0' },
+    ],
+  ]);
+  expect(depGraph.countPathsToRoot({ name: 'foo', version: '2' })).toBe(1);
 });
 
 test('fromJSON root is not really root', () => {

--- a/test/core/direct-deps-leading-to.test.ts
+++ b/test/core/direct-deps-leading-to.test.ts
@@ -41,13 +41,29 @@ describe('directDepsLeadingTo', () => {
     expect(depGraph.directDepsLeadingTo(pkg)).toEqual(expected);
   });
 
-  test('it works with a cyclic dep-graph', () => {
-    const cyclic = depGraphLib.createFromJSON(
-      helpers.loadFixture('cyclic-dep-graph.json'),
-    );
-    const pkg = { name: 'baz', version: '4' };
-    const expected = [{ name: 'foo', version: '2' }];
+  describe('get direct deps for cyclic graphs', () => {
+    test('it works with a simple cyclic dep-graph', () => {
+      const cyclic = depGraphLib.createFromJSON(
+        helpers.loadFixture('cyclic-dep-graph.json'),
+      );
+      const pkg = { name: 'baz', version: '4' };
+      const expected = [{ name: 'foo', version: '2' }];
 
-    expect(cyclic.directDepsLeadingTo(pkg)).toEqual(expected);
+      expect(cyclic.directDepsLeadingTo(pkg)).toEqual(expected);
+    });
+
+    test('it works with a surreal cyclic dep-graph', () => {
+      const cyclic = depGraphLib.createFromJSON(
+        helpers.loadFixture('heavily-cyclic-dep-graph.json'),
+      );
+      const pkg = { name: 'B', version: '4' };
+      const expected = [
+        { name: 'B', version: '4' },
+        { name: 'D', version: '4' },
+        { name: 'C', version: '4' },
+      ];
+
+      expect(cyclic.directDepsLeadingTo(pkg)).toEqual(expected);
+    });
   });
 });

--- a/test/fixtures/heavily-cyclic-dep-graph.json
+++ b/test/fixtures/heavily-cyclic-dep-graph.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "npm"
+  },
+  "pkgs": [
+    {
+      "id": "A@4",
+      "info": {
+        "name": "A",
+        "version": "4"
+      }
+    },
+    {
+      "id": "B@4",
+      "info": {
+        "name": "B",
+        "version": "4"
+      }
+    },
+    {
+      "id": "C@4",
+      "info": {
+        "name": "C",
+        "version": "4"
+      }
+    },
+    {
+      "id": "D@4",
+      "info": {
+        "name": "D",
+        "version": "4"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "A@4|x",
+    "nodes": [
+      {
+        "nodeId": "A@4|x",
+        "pkgId": "A@4",
+        "deps": [
+          {
+            "nodeId": "B@4|x"
+          },
+          {
+            "nodeId": "D@4|x"
+          },
+          {
+            "nodeId": "C@4|x"
+          }
+        ]
+      },
+      {
+        "nodeId": "B@4|x",
+        "pkgId": "B@4",
+        "deps": [
+          {
+            "nodeId": "C@4|x"
+          },
+          {
+            "nodeId": "D@4|x"
+          }
+        ]
+      },
+      {
+        "nodeId": "C@4|x",
+        "pkgId": "C@4",
+        "deps": [
+          {
+            "nodeId": "D@4|x"
+          },
+          {
+            "nodeId": "B@4|x"
+          }
+        ]
+      },
+      {
+        "nodeId": "D@4|x",
+        "pkgId": "D@4",
+        "deps": [
+          {
+            "nodeId": "C@4|x"
+          },
+          {
+            "nodeId": "B@4|x"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/legacy/__snapshots__/to-dep-tree.test.ts.snap
+++ b/test/legacy/__snapshots__/to-dep-tree.test.ts.snap
@@ -1,0 +1,264 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cyclic graphs cyclic graph to tree 1`] = `
+Object {
+  "dependencies": Object {
+    "foo": Object {
+      "dependencies": Object {
+        "bar": Object {
+          "dependencies": Object {
+            "baz": Object {
+              "dependencies": Object {
+                "foo": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "foo",
+                  "version": "2",
+                },
+              },
+              "name": "baz",
+              "version": "4",
+            },
+          },
+          "name": "bar",
+          "version": "3",
+        },
+      },
+      "name": "foo",
+      "version": "2",
+    },
+  },
+  "name": "toor",
+  "packageFormatVersion": "pip:0.0.1",
+  "type": "pip",
+  "version": "1.0.0",
+}
+`;
+
+exports[`Cyclic graphs heavily cyclic graph to tree and back (X2) 1`] = `
+Object {
+  "dependencies": Object {
+    "B": Object {
+      "dependencies": Object {
+        "C": Object {
+          "dependencies": Object {
+            "B": Object {
+              "labels": Object {
+                "cyclic": "true",
+              },
+              "name": "B",
+              "version": "4",
+            },
+            "D": Object {
+              "dependencies": Object {
+                "B": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "B",
+                  "version": "4",
+                },
+                "C": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "C",
+                  "version": "4",
+                },
+              },
+              "name": "D",
+              "version": "4",
+            },
+          },
+          "name": "C",
+          "version": "4",
+        },
+        "D": Object {
+          "dependencies": Object {
+            "B": Object {
+              "labels": Object {
+                "cyclic": "true",
+              },
+              "name": "B",
+              "version": "4",
+            },
+            "C": Object {
+              "dependencies": Object {
+                "B": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "B",
+                  "version": "4",
+                },
+                "D": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "D",
+                  "version": "4",
+                },
+              },
+              "name": "C",
+              "version": "4",
+            },
+          },
+          "name": "D",
+          "version": "4",
+        },
+      },
+      "name": "B",
+      "version": "4",
+    },
+    "C": Object {
+      "dependencies": Object {
+        "B": Object {
+          "dependencies": Object {
+            "C": Object {
+              "labels": Object {
+                "cyclic": "true",
+              },
+              "name": "C",
+              "version": "4",
+            },
+            "D": Object {
+              "dependencies": Object {
+                "B": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "B",
+                  "version": "4",
+                },
+                "C": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "C",
+                  "version": "4",
+                },
+              },
+              "name": "D",
+              "version": "4",
+            },
+          },
+          "name": "B",
+          "version": "4",
+        },
+        "D": Object {
+          "dependencies": Object {
+            "B": Object {
+              "dependencies": Object {
+                "C": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "C",
+                  "version": "4",
+                },
+                "D": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "D",
+                  "version": "4",
+                },
+              },
+              "name": "B",
+              "version": "4",
+            },
+            "C": Object {
+              "labels": Object {
+                "cyclic": "true",
+              },
+              "name": "C",
+              "version": "4",
+            },
+          },
+          "name": "D",
+          "version": "4",
+        },
+      },
+      "name": "C",
+      "version": "4",
+    },
+    "D": Object {
+      "dependencies": Object {
+        "B": Object {
+          "dependencies": Object {
+            "C": Object {
+              "dependencies": Object {
+                "B": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "B",
+                  "version": "4",
+                },
+                "D": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "D",
+                  "version": "4",
+                },
+              },
+              "name": "C",
+              "version": "4",
+            },
+            "D": Object {
+              "labels": Object {
+                "cyclic": "true",
+              },
+              "name": "D",
+              "version": "4",
+            },
+          },
+          "name": "B",
+          "version": "4",
+        },
+        "C": Object {
+          "dependencies": Object {
+            "B": Object {
+              "dependencies": Object {
+                "C": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "C",
+                  "version": "4",
+                },
+                "D": Object {
+                  "labels": Object {
+                    "cyclic": "true",
+                  },
+                  "name": "D",
+                  "version": "4",
+                },
+              },
+              "name": "B",
+              "version": "4",
+            },
+            "D": Object {
+              "labels": Object {
+                "cyclic": "true",
+              },
+              "name": "D",
+              "version": "4",
+            },
+          },
+          "name": "C",
+          "version": "4",
+        },
+      },
+      "name": "D",
+      "version": "4",
+    },
+  },
+  "name": "A",
+  "packageFormatVersion": "npm:0.0.1",
+  "type": "npm",
+  "version": "4",
+}
+`;


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Handle cyclic graphs in all exported methods:
* `legacy.graphToDepTree(...)` - recursing up to first cyclic node, and labeling it as such.
* `DepGraph.pkgPathsToRoot(...)` - for a path with a cycle, picking the short path to root, without a cycle.
* `DepGraph.countPathsToRoot(...)` - similarly to `pkgPathsToRoot()`.



**TODO**: the current cyclic-graph fixture is very basic, having only a single path per package and a single cycle. Better change it or add more fixtures for better coverage. Some ideas:
* some packages with more than one path to root
* multiple cycles on same path?
* cycle with root package? 🤔 (not sure it's a real usecase)
