### PR TITLE
feat: add directDepsLeadingTo public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ export interface DepGraph {
     name: string;
     version?: string;
   }>>;
+  directDepsLeadingTo(pkg: Pkg): Array<{
+    name: string;
+    version?: string;
+  }>;
   countPathsToRoot(pkg: Pkg): number;
   toJSON(): DepGraphData;
   equals(other: DepGraph, options?: { compareRoot?: boolean }): boolean;

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -183,6 +183,16 @@ class DepGraphImpl implements types.DepGraphInternal {
     return this.nodeEquals(this, this.rootNodeId, otherDepGraph, otherDepGraph.rootNodeId, compareRoot);
   }
 
+  public directDepsLeadingTo(pkg: types.Pkg): types.PkgInfo[] {
+    const pkgNodes = this.getPkgNodeIds(pkg);
+    const directDeps = this.getNodeDepsNodeIds(this.rootNodeId);
+    const nodes = directDeps.filter((directDep) => {
+      const reachableNodes = graphlib.alg.postorder(this._graph, [directDep]);
+      return reachableNodes.filter((node) => pkgNodes.includes(node)).length;
+    });
+    return nodes.map((node) => this.getNodePkg(node));
+  }
+
   public toJSON(): types.DepGraphData {
     const nodeIds = this._graph.nodes();
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -94,6 +94,7 @@ export interface DepGraph {
   getPkgNodes(pkg: Pkg): Node[];
   toJSON(): DepGraphData;
   pkgPathsToRoot(pkg: Pkg): PkgInfo[][];
+  directDepsLeadingTo(pkg: Pkg): PkgInfo[];
   countPathsToRoot(pkg: Pkg): number;
   equals(other: DepGraph, options?: { compareRoot?: boolean }): boolean;
 }

--- a/test/core/direct-deps-leading-to.test.ts
+++ b/test/core/direct-deps-leading-to.test.ts
@@ -1,0 +1,53 @@
+import * as depGraphLib from "../../src";
+import * as helpers from "../helpers";
+
+describe("directDepsLeadingTo", () => {
+  const depGraph = depGraphLib.createFromJSON(
+    helpers.loadFixture("goof-graph.json")
+  );
+
+  test("it gets the package itself if it is a direct dependency", () => {
+    const pkg = { name: "consolidate", version: "0.14.5" };
+
+    expect(depGraph.directDepsLeadingTo(pkg)).toEqual([pkg]);
+  });
+
+  test("it gets the direct deps leading to a package, respecting the version", () => {
+    const pkgA = { name: "bluebird", version: "2.9.26" };
+    const pkgB = { name: "bluebird", version: "3.5.2" };
+
+    const expectedDepsA = [{ name: "mongoose", version: "4.2.4" }];
+    const expectedDepsB = [
+      { name: "consolidate", version: "0.14.5" },
+      { name: "tap", version: "5.8.0" }
+    ];
+
+    const directDepsForA = depGraph.directDepsLeadingTo(pkgA);
+    const directDepsForB = depGraph.directDepsLeadingTo(pkgB);
+
+    expect(directDepsForA).toEqual(expectedDepsA);
+    expect(directDepsForB).toEqual(expectedDepsB);
+    expect(directDepsForA).not.toEqual(directDepsForB);
+  });
+
+  test("it gets the correct direct deps for a deep dependency", () => {
+    const pkg = { name: "isarray", version: "0.0.1" };
+    const expected = [
+      { name: "express-fileupload", version: "0.0.5" },
+      { name: "mongoose", version: "4.2.4" },
+      { name: "tap", version: "5.8.0" }
+    ];
+
+    expect(depGraph.directDepsLeadingTo(pkg)).toEqual(expected);
+  });
+
+  test("it works with a cyclic dep-graph", () => {
+    const cyclic = depGraphLib.createFromJSON(
+      helpers.loadFixture("cyclic-dep-graph.json")
+    );
+    const pkg = { name: "baz", version: "4" };
+    const expected = [{ name: "foo", version: "2" }];
+
+    expect(cyclic.directDepsLeadingTo(pkg)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Add a public method to get the direct dependencies which introduced the specified package.
