### PR TITLE
fix: Fix label instance reuse bug during pruning

### DIFF
--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -283,7 +283,7 @@ async function buildSubtree(
     depTree.versionProvenance = nodeInfo.versionProvenance;
   }
   if (nodeInfo.labels) {
-    depTree.labels = nodeInfo.labels;
+    depTree.labels = { ...nodeInfo.labels };
   }
 
   const depInstanceIds = depGraph.getNodeDepsNodeIds(nodeId);

--- a/test/fixtures/pruneable-tree-multi-top-level-deps-pruned.json
+++ b/test/fixtures/pruneable-tree-multi-top-level-deps-pruned.json
@@ -22,6 +22,9 @@
                     "vuln": "yes"
                   }
                 }
+              },
+              "labels": {
+                "foo": "bar"
               }
             }
           }
@@ -34,6 +37,7 @@
               "name": "c",
               "version": "1.0.0",
               "labels": {
+                "foo": "bar",
                 "pruned": "true"
               }
             }
@@ -60,6 +64,9 @@
                     "vuln": "yes"
                   }
                 }
+              },
+              "labels": {
+                "foo": "bar"
               }
             }
           }

--- a/test/fixtures/pruneable-tree-multi-top-level-deps.json
+++ b/test/fixtures/pruneable-tree-multi-top-level-deps.json
@@ -22,6 +22,9 @@
                     "vuln": "yes"
                   }
                 }
+              },
+              "labels": {
+                "foo": "bar"
               }
             }
           }
@@ -41,6 +44,9 @@
                     "vuln": "yes"
                   }
                 }
+              },
+              "labels": {
+                "foo": "bar"
               }
             }
           }
@@ -66,6 +72,9 @@
                     "vuln": "yes"
                   }
                 }
+              },
+              "labels": {
+                "foo": "bar"
               }
             }
           }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes a label instance reuse bug during pruning.

Why is this a fixture update and not an explicit focused test?

- It's an implementation bug that does not deserve negative testing