### PR TITLE
feat: support scratch images

### DIFF
--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -251,7 +251,7 @@ function constructPackageFormatVersion(pkgType: string): string {
 }
 
 function constructTargetOS(depGraph: types.DepGraph): { name: string; version: string; } | void {
-  if (['apk', 'apt', 'deb', 'rpm'].indexOf(depGraph.pkgManager.name) === -1) {
+  if (['apk', 'apt', 'deb', 'rpm', 'linux'].indexOf(depGraph.pkgManager.name) === -1) {
     // .targetOS is undefined unless its a linux pkgManager
     return;
   }

--- a/test/fixtures/os-linux-scratch-dep-graph.json
+++ b/test/fixtures/os-linux-scratch-dep-graph.json
@@ -1,0 +1,30 @@
+{
+    "schemaVersion": "1.2.0",
+    "pkgManager": {
+      "name": "linux",
+      "repositories": [
+        {
+          "alias": "unknown:0.0"
+        }
+      ]
+    },
+    "pkgs": [
+      {
+        "id": "docker-image|scratch@0",
+        "info": {
+          "name": "docker-image|scratch",
+          "version": "0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "docker-image|scratch@0",
+          "deps": []
+        }
+      ]
+    }
+  }

--- a/test/fixtures/os-linux-scratch-dep-tree.json
+++ b/test/fixtures/os-linux-scratch-dep-tree.json
@@ -1,0 +1,10 @@
+{
+    "name": "docker-image|scratch",
+    "version": "0",
+    "type": "linux",
+    "packageFormatVersion": "linux:0.0.1",
+    "targetOS": {
+      "name": "unknown",
+      "version": "0.0"
+    }
+  }

--- a/test/legacy/to-dep-tree.test.ts
+++ b/test/legacy/to-dep-tree.test.ts
@@ -46,6 +46,12 @@ describe('dep-trees survive serialisation through dep-graphs', () => {
       pkgType: 'rpm',
     },
     {
+      description: 'os dep-tree (linux - scratch image)',
+      path: 'os-linux-scratch-dep-tree.json',
+      pkgManagerName: 'linux',
+      pkgType: 'linux',
+    },
+    {
       description: 'maven dep-tree',
       path: 'maven-dep-tree.json',
       pkgManagerName: 'maven',


### PR DESCRIPTION
Imported scratch images have linux as a package manager
DepTree should include targetOS.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

To support scratch images import, we're currently setting the pkgManager on these projects as `linux`.
Needed to add it so `targetOS` will be included in the depTree.

#### Where should the reviewer start?

Added a test with fixtures, `targetOS` should be included in the depTree after conversion.

#### How should this be manually tested?

Import a docker project with container image built from scratch.
i.e `snyk monitor --docker busybox:1.31.1`
Dep graph should be:
```
{
  "schemaVersion": "1.2.0",
  "pkgManager": {
    "name": "linux",
    "repositories": [
      {
        "alias": "unknown:0.0"
      }
    ]
  },
  "pkgs": [
    {
      "id": "docker-image|busybox@1.31.1",
      "info": {
        "name": "docker-image|busybox",
        "version": "1.31.1"
      }
    }
  ],
  "graph": {
    "rootNodeId": "root-node",
    "nodes": [
      {
        "nodeId": "root-node",
        "pkgId": "docker-image|busybox@1.31.1",
        "deps": []
      }
    ]
  }
}
```

Dep tree:
```
{
  "name": "docker-image|busybox",
  "version": "1.31.1",
  "type": "linux",
  "packageFormatVersion": "linux:0.0.1",
  "targetOS": {
    "name": "unknown",
    "version": "0.0"
  }
}
```

#### Additional questions

Let me know if anything is missing :) 