### PR TITLE
feat: drop Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ notifications:
   email: false
 language: node_js
 node_js:
+  - "12"
   - "10"
   - "8"
-  - "6"
 cache: npm
 script:
   - "npm run lint"
@@ -15,7 +15,7 @@ jobs:
   include:
     - stage: npm release
       if: branch = master AND type != pull_request
-      node_js: "10"
+      node_js: "12"
       script: skip
       after_success:
         - npx semantic-release

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es5",
+    "target": "es2017",
     "lib": [
-      "es2015"
+      "es2017"
     ],
     "module": "commonjs",
     "sourceMap": true,


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Node 6 reached End-Of-Life at April 30, 2019.

The snyk CLI was the only dependant we had that supported Node 6, and it
recently deprecated Node 6 too: https://github.com/snyk/snyk/releases/tag/v1.301.0

By updating the `target` to `es2017` in `tsconfig.json` we get native `async/await`

