### PR TITLE
fix: package.json: update min supported node to 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "npm run build"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

specify min required node version as 8, following the drop of Node 6 support in https://github.com/snyk/dep-graph/pull/53.
