### PR TITLE
fix: Move prettier to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/object-hash": "^1.3.1",
     "@types/semver": "^7",
     "jest": "^25",
-    "prettier": "^1.9.1",
     "ts-jest": "^25",
     "ts-node": "^8",
     "tslint": "^6",
@@ -45,6 +44,7 @@
     "@snyk/graphlib": "2.1.9-patch",
     "@snyk/lodash": "4.17.15-patch",
     "object-hash": "^2.0.3",
+    "prettier": "^1.9.1",
     "semver": "^7.3.2",
     "source-map-support": "^0.5.19",
     "tslib": "^1.11.1"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Moves `prettier` to `devDependencies`

#### Any background context you want to provide?
When `prettier` was added to this repo in 9b45ff1, it was added as a `dependency` and is therefore installed in any project that uses a recent version of `snyk`