### PR TITLE
Refactor: Improved depGraph performance

### DIFF
--- a/post-test.dump
+++ b/post-test.dump
@@ -1,0 +1,25 @@
+  console.log
+    ===========
+    rss 110.72 MB
+    heapTotal 72.34 MB
+    heapUsed 50.26 MB
+    external 4.54 MB
+    ===========
+
+      at dumpMemory (test/legacy/performance.test.ts:31:11)
+
+  console.log
+    ===========
+    rss 164.04 MB
+    heapTotal 116.35 MB
+    heapUsed 96.63 MB
+    external 3.42 MB
+    ===========
+
+      at dumpMemory (test/legacy/performance.test.ts:31:11)
+
+  console.info
+    Execution time (hr): 0s 200.061817ms
+
+      at Object.<anonymous> (test/legacy/performance.test.ts:44:13)
+

--- a/pre-test.dump
+++ b/pre-test.dump
@@ -1,0 +1,25 @@
+  console.log
+    ===========
+    rss 110.63 MB
+    heapTotal 72.09 MB
+    heapUsed 50.26 MB
+    external 4.53 MB
+    ===========
+
+      at dumpMemory (test/legacy/performance.test.ts:31:11)
+
+  console.log
+    ===========
+    rss 163.96 MB
+    heapTotal 115.85 MB
+    heapUsed 96.63 MB
+    external 3.42 MB
+    ===========
+
+      at dumpMemory (test/legacy/performance.test.ts:31:11)
+
+  console.info
+    Execution time (hr): 0s 236.379585ms
+
+      at Object.<anonymous> (test/legacy/performance.test.ts:44:13)
+

--- a/src/core/InternalSet.ts
+++ b/src/core/InternalSet.ts
@@ -1,0 +1,17 @@
+export class InternalSet {
+  state = {};
+
+  constructor(oldState?: InternalSet) {
+    Object.keys(oldState?.state || {}).forEach(k=>this.state[k] = true)
+    return this;
+  }
+
+  add(k) {
+    this.state[k] = true;
+    return this;
+  }
+
+  has(k: string): boolean {
+    return this.state[k];
+  }
+}

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -5,6 +5,7 @@ import { DepGraphBuilder } from '../core/builder';
 import { EventLoopSpinner } from './event-loop-spinner';
 
 import objectHash = require('object-hash');
+import { InternalSet } from '../core/InternalSet';
 
 export { depTreeToGraph, graphToDepTree, DepTree };
 
@@ -233,7 +234,7 @@ async function graphToDepTree(
     depGraph,
     depGraph.rootNodeId,
     eventLoopSpinner,
-    new Set(),
+    new InternalSet(),
     opts.deduplicateWithinTopLevelDeps ? null : false,
   );
 
@@ -282,8 +283,8 @@ async function buildSubtree(
   depGraph: types.DepGraphInternal,
   nodeId: string,
   eventLoopSpinner: EventLoopSpinner,
-  ancestorsSet: Set<string>,
-  maybeDeduplicationSet: Set<string> | null | false = null, // false = disabled; null = not in deduplication scope yet
+  ancestorsSet: InternalSet,
+  maybeDeduplicationSet: InternalSet | null | false = null, // false = disabled; null = not in deduplication scope yet
 ): Promise<DepTree> {
   const isRoot = nodeId === depGraph.rootNodeId;
   const nodePkg = depGraph.getNodePkg(nodeId);
@@ -332,9 +333,9 @@ async function buildSubtree(
     // Deduplication of nodes occurs only within a scope of a top-level dependency.
     // Therefore, every top-level dep gets an independent set to track duplicates.
     if (isRoot && maybeDeduplicationSet !== false) {
-      maybeDeduplicationSet = new Set();
+      maybeDeduplicationSet = new InternalSet();
     }
-    const ancestors = new Set(ancestorsSet).add(nodeId);
+    const ancestors = new InternalSet(ancestorsSet).add(nodeId);
     const subtree = await buildSubtree(
       depGraph,
       depInstId,


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
WIP for https://github.com/snyk/dep-graph/pull/48

### Background
This is in continuation to #48 where we've used `Set` as our unique-entries data-structure, assuming the execution time and runtime complexity match the specs;
Empirically - we've found that `Set` reacts much slower compared to `{}`;
This PR was made in order to verify this assumption, and if yes - introduce a refactor with `{}` 
