### PR TITLE
fix: Roll `semver` back to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@snyk/graphlib": "2.1.9-patch",
     "@snyk/lodash": "4.17.15-patch",
     "object-hash": "^2.0.3",
-    "semver": "^7.3.2",
+    "semver": "^6.0.0",
     "source-map-support": "^0.5.19",
     "tslib": "^1.11.1"
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- Rolls `semver` back to 6
- `semver` 7 dropped support for Node 8 (which we still support for now)

#### Where should the reviewer start?

https://github.com/snyk/dep-graph/pull/58#issuecomment-629650124
