### PR TITLE
feat: drop @snyk/lodash dependency, + bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ts-jest": "^25",
     "ts-node": "^8",
     "tslint": "^6",
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.3"
   },
   "dependencies": {
     "@snyk/graphlib": "2.1.9-patch",
@@ -47,6 +47,6 @@
     "object-hash": "^2.0.3",
     "semver": "^6.0.0",
     "source-map-support": "^0.5.19",
-    "tslib": "^1.11.1"
+    "tslib": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@snyk/graphlib": "2.1.9-patch",
-    "@snyk/lodash": "4.17.15-patch",
+    "lodash.isequal": "^4.5.0",
     "object-hash": "^2.0.3",
     "semver": "^6.0.0",
     "source-map-support": "^0.5.19",

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -1,4 +1,4 @@
-import * as _ from '@snyk/lodash';
+import * as _isEqual from 'lodash.isequal';
 import * as graphlib from '@snyk/graphlib';
 import * as types from './types';
 import { createFromJSON } from './create-from-json';
@@ -255,7 +255,7 @@ class DepGraphImpl implements types.DepGraphInternal {
       const pkgB = graphB.getNodePkg(nodeIdB);
 
       // Compare PkgInfo (name and version).
-      if (!_.isEqual(pkgA, pkgB)) {
+      if (!_isEqual(pkgA, pkgB)) {
         return false;
       }
 
@@ -263,7 +263,7 @@ class DepGraphImpl implements types.DepGraphInternal {
       const infoB = graphB.getNode(nodeIdB);
 
       // Compare NodeInfo (VersionProvenance and labels).
-      if (!_.isEqual(infoA, infoB)) {
+      if (!_isEqual(infoA, infoB)) {
         return false;
       }
     }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import * as _ from '@snyk/lodash';
+import * as _isEqual from 'lodash.isequal';
 import * as fs from 'fs';
 import * as path from 'path';
 import { PkgInfo } from '../src';
@@ -35,8 +35,8 @@ export function depTreesEqual(a: any, b: any) {
   }
 
   if (
-    !_.isEqual(a.labels, b.labels) ||
-    !_.isEqual(a.versionProvenance, b.versionProvenance)
+    !_isEqual(a.labels, b.labels) ||
+    !_isEqual(a.versionProvenance, b.versionProvenance)
   ) {
     return false;
   }


### PR DESCRIPTION
#### What does this PR do?

Swap out `@snyk/lodash` for `lodash.isequal`, our only use.

Bump some stuff while we're here.