### PR TITLE
fix: hack: revert typescript -> 3.8, sinon fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ts-jest": "^25",
     "ts-node": "^8",
     "tslint": "^6",
-    "typescript": "^3.9.3"
+    "typescript": "~3.8.3"
   },
   "dependencies": {
     "@snyk/graphlib": "2.1.9-patch",


### PR DESCRIPTION
Typescript 3.9 breaks sinon stubbing in some of our APIs,
which breaks tests in other services. It does not break
tests in this service. Those other services need to be
fixed to not need this, but, for now, let's just rollback.
