### PR TITLE
fix: Switch back to `graphlib`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/snyk/dep-graph/issues"
   },
   "devDependencies": {
+    "@types/graphlib": "^2.1.6",
     "@types/jest": "^25",
     "@types/node": "^8",
     "@types/object-hash": "^1.3.1",
@@ -42,7 +43,7 @@
     "typescript": "~3.8.3"
   },
   "dependencies": {
-    "@snyk/graphlib": "2.1.9-patch.2",
+    "graphlib": "^2.1.8",
     "lodash.isequal": "^4.5.0",
     "object-hash": "^2.0.3",
     "semver": "^6.0.0",

--- a/src/core/builder.ts
+++ b/src/core/builder.ts
@@ -1,4 +1,4 @@
-import * as graphlib from '@snyk/graphlib';
+import * as graphlib from 'graphlib';
 import * as types from './types';
 import { DepGraphImpl } from './dep-graph';
 

--- a/src/core/create-from-json.ts
+++ b/src/core/create-from-json.ts
@@ -1,5 +1,5 @@
 import * as semver from 'semver';
-import * as graphlib from '@snyk/graphlib';
+import * as graphlib from 'graphlib';
 import * as types from './types';
 
 import { DepGraph, DepGraphData, GraphNode } from './types';

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -1,5 +1,5 @@
 import * as _isEqual from 'lodash.isequal';
-import * as graphlib from '@snyk/graphlib';
+import * as graphlib from 'graphlib';
 import * as types from './types';
 import { createFromJSON } from './create-from-json';
 

--- a/src/core/validate-graph.ts
+++ b/src/core/validate-graph.ts
@@ -1,4 +1,4 @@
-import * as graphlib from '@snyk/graphlib';
+import * as graphlib from 'graphlib';
 import { ValidationError } from './errors';
 
 function assert(condition: boolean, msg: string) {


### PR DESCRIPTION
#### What does this PR do?

- Lodash has released a non-breaking update that fixes the vulns
  we were avoiding, so we can stop using our fork
