### PR TITLE
feat: libraries do not register source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lodash.isequal": "^4.5.0",
     "object-hash": "^2.0.3",
     "semver": "^6.0.0",
-    "source-map-support": "^0.5.19",
     "tslib": "^1.13.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import 'source-map-support/register';
-
 export {
   DepGraph,
   DepGraphData,


### PR DESCRIPTION
This forces applications to pick up source-map-support, which is not
always wanted, and may be causing them issues.
