### PR TITLE
feat: add memoization to when converting a graph into a tree

### DIFF
--- a/test/legacy/stress.test.ts
+++ b/test/legacy/stress.test.ts
@@ -1,0 +1,50 @@
+import * as depGraphLib from '../../src';
+import { graphToDepTree } from '../../src/legacy';
+
+const dependencyName = 'needle';
+
+async function generateLargeGraph(width: number) {
+  const builder = new depGraphLib.DepGraphBuilder(
+    { name: 'npm' },
+    { name: 'root', version: '1.2.3' },
+  );
+  const rootNodeId = 'root-node';
+
+  const deepDependency = { name: dependencyName, version: '1.2.3' };
+  const deepDependency2 = { name: dependencyName + 2, version: '1.2.3' };
+
+  builder.addPkgNode(deepDependency, dependencyName);
+  builder.addPkgNode(deepDependency2, deepDependency2.name);
+  builder.connectDep(rootNodeId, dependencyName);
+  builder.connectDep(deepDependency.name, deepDependency2.name);
+
+  for (let j = 0; j < width / 2; j++) {
+    const shallowName = `id-${j}`;
+    const shallowDependency = { name: shallowName, version: '1.2.3' };
+
+    builder.addPkgNode(shallowDependency, shallowName);
+    builder.connectDep(rootNodeId, shallowName);
+    builder.connectDep(shallowName, dependencyName);
+  }
+
+  for (let j = 0; j < width / 2; j++) {
+    const shallowName = `second-${j}`;
+    const shallowDependency = { name: shallowName, version: '1.2.3' };
+
+    builder.addPkgNode(shallowDependency, shallowName);
+    builder.connectDep(deepDependency2.name, shallowName);
+  }
+
+  return builder.build();
+}
+
+describe('stress tests', () => {
+  test('graphToDepTree() with memoization (without deduplicateWithinTopLevelDeps) succeed for large dep-graphs', async () => {
+    const graph = await generateLargeGraph(125000);
+
+    const depTree = await graphToDepTree(graph, 'gomodules', {
+      deduplicateWithinTopLevelDeps: false,
+    });
+    expect(depTree).toBeDefined();
+  });
+});


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
It adds memoization in the `graphToDepTree`
This will result in reused objects in a tree instead, for example the following graph
```
A --> B --> D
  \-> C --> B
```
Instead of creating `B --> D` twice (as today), it will reuse the B subtree
