### PR TITLE
feat: add memoization when converting tree to graph

### DIFF
--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -75,7 +75,11 @@ async function buildGraph(
   pkgName: string,
   eventLoopSpinner: EventLoopSpinner,
   isRoot = false,
+  memoizationMap: Map<DepTree, string> = new Map(),
 ): Promise<string> {
+  if (memoizationMap.has(depTree)) {
+    return memoizationMap.get(depTree)!;
+  }
   const getNodeId = (
     name: string,
     version: string | undefined,
@@ -103,6 +107,8 @@ async function buildGraph(
       dep,
       depName,
       eventLoopSpinner,
+      false,
+      memoizationMap,
     );
 
     const depPkg: types.PkgInfo = {
@@ -160,6 +166,7 @@ async function buildGraph(
   if (depNodesIds.length > 0 && eventLoopSpinner.isStarving()) {
     await eventLoopSpinner.spin();
   }
+  memoizationMap.set(depTree, treeHash);
   return treeHash;
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Like https://github.com/snyk/dep-graph/pull/73 (which affects graphToDepTree), It adds memoization in the depTreeToGraph

For a **very large tree** (that was generated using the memoization from https://github.com/snyk/dep-graph/pull/73), it reduced the time from 20000ms to less than 200ms