### PR TITLE
feat: add cutCycles and reconnectCycles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 coverage/
 package-lock.json
+.idea

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "typescript": "~3.8.3"
   },
   "dependencies": {
+    "event-loop-spinner": "^2.0.0",
     "graphlib": "^2.1.8",
     "lodash.isequal": "^4.5.0",
     "object-hash": "^2.0.3",

--- a/src/cycles/cut-cycles.ts
+++ b/src/cycles/cut-cycles.ts
@@ -1,0 +1,72 @@
+import { eventLoopSpinner } from 'event-loop-spinner';
+import { buildEdge } from './edges';
+import { DepGraph, DepGraphInternal, NodeInfo } from '../core/types';
+import { DepGraphBuilder } from '..';
+import { findCycle } from './find-cycles';
+import { getGraphMaps, EdgesMap, NodeId } from './get-graph-maps';
+
+export async function cutCycles(depGraph: DepGraph) {
+  if (!(depGraph as DepGraphInternal).hasCycles()) {
+    return depGraph;
+  }
+  const { nodesMap, edgesMap, pkgsInfoMap } = getGraphMaps(depGraph);
+
+  const removedEdgesMap: EdgesMap = new Map();
+  let cycle = getCycle(edgesMap);
+
+  while (cycle) {
+    const from = cycle[0];
+    const to = cycle[cycle.length - 1];
+    edgesMap.set(
+      from,
+      edgesMap.get(from)!.filter((nodeId) => nodeId !== to),
+    );
+
+    const index = nodesMap
+      .get(from)!
+      .deps.findIndex(({ nodeId }) => nodeId === to);
+
+    if (!removedEdgesMap.has(from)) removedEdgesMap.set(from, []);
+    removedEdgesMap.get(from)!.push(buildEdge(index, to));
+    cycle = getCycle(edgesMap);
+
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+  }
+
+  const rootPkg = depGraph.rootPkg;
+  const depGraphBuilder = new DepGraphBuilder(depGraph.pkgManager, rootPkg);
+
+  for (const { nodeId, info, pkgId } of nodesMap.values()) {
+    if (nodeId === 'root-node') continue;
+
+    let nodeInfo: NodeInfo | undefined;
+    if (removedEdgesMap.get(nodeId)) {
+      nodeInfo = info ? { ...info } : {};
+      nodeInfo.labels = nodeInfo.labels || {};
+      nodeInfo.labels['removed-cyclic-deps'] = removedEdgesMap
+        .get(nodeId)!
+        .join();
+    }
+    depGraphBuilder.addPkgNode(pkgsInfoMap.get(pkgId)!, nodeId, nodeInfo);
+
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+  }
+
+  for (const [from, toNode] of edgesMap.entries()) {
+    toNode.forEach((toNodeId) => depGraphBuilder.connectDep(from, toNodeId));
+
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+  }
+
+  return depGraphBuilder.build();
+}
+
+function getCycle(graph: EdgesMap): NodeId[] | null {
+  return findCycle<NodeId>('root-node', (nodeId) => graph.get(nodeId)!);
+}

--- a/src/cycles/edges.ts
+++ b/src/cycles/edges.ts
@@ -1,0 +1,10 @@
+const DELIMITER = `@@`;
+
+export function buildEdge(index: number, to: string) {
+  return `${index}${DELIMITER}${to}`;
+}
+
+export function splitEdge(edge: string) {
+  const [index, to] = edge.split(DELIMITER);
+  return { index: parseInt(index, 0), to };
+}

--- a/src/cycles/find-cycles.ts
+++ b/src/cycles/find-cycles.ts
@@ -1,0 +1,42 @@
+// This file is a modification of https://github.com/jcoreio/find-cycle/blob/master/directed.js
+// It adds typescript support and get only one startNode (instead of multiple)
+
+export function findCycle<Node>(
+  startNode: Node,
+  getChildrenNodes: (node: Node) => Node[],
+) {
+  function getChildrenIterator(node): Iterator<Node> {
+    const nodes = getChildrenNodes(node) || [];
+    return nodes[Symbol.iterator]();
+  }
+
+  const visited = new Set<Node>([startNode]);
+  const nodeStack: Node[] = [startNode];
+  const connectedNodeStack: Iterator<Node>[] = [getChildrenIterator(startNode)];
+  const nodeIndexes = new Map<Node, number>([[startNode, 0]]);
+
+  while (nodeStack.length) {
+    const connectedNodes = connectedNodeStack[connectedNodeStack.length - 1];
+
+    const next = connectedNodes.next();
+    if (next.done) {
+      connectedNodeStack.pop();
+      const removedNode = nodeStack.pop()!;
+      nodeIndexes.delete(removedNode);
+      continue;
+    }
+    const nextNode = next.value;
+    const cycleStartIndex = nodeIndexes.get(nextNode);
+    if (cycleStartIndex != null) {
+      // found a cycle!
+      return nodeStack.slice(cycleStartIndex).reverse();
+    }
+    if (visited.has(nextNode)) continue;
+    visited.add(nextNode);
+    nodeIndexes.set(nextNode, nodeStack.length);
+    nodeStack.push(nextNode);
+    connectedNodeStack.push(getChildrenIterator(nextNode));
+  }
+
+  return null;
+}

--- a/src/cycles/get-graph-maps.ts
+++ b/src/cycles/get-graph-maps.ts
@@ -1,0 +1,40 @@
+import { DepGraph, DepGraphData, PkgInfo } from '..';
+import { GraphNode } from '../core/types';
+
+type PkgId = string;
+export type NodeId = string;
+export type EdgesMap = Map<NodeId, NodeId[]>;
+type NodesMap = Map<NodeId, GraphNode>;
+type PkgsInfoMap = Map<PkgId, PkgInfo>;
+
+type GraphMaps = {
+  nodesMap: NodesMap;
+  edgesMap: EdgesMap;
+  pkgsInfoMap: PkgsInfoMap;
+};
+
+export function getGraphMaps(depGraph: DepGraph): GraphMaps {
+  const depGraphData: DepGraphData = depGraph.toJSON();
+  const nodes: GraphNode[] = depGraphData.graph.nodes;
+
+  const nodesMap = nodes.reduce(
+    (map, graphNode) => map.set(graphNode.nodeId, graphNode),
+    new Map() as NodesMap,
+  );
+
+  const edgesMap = nodes.reduce(
+    (map, graphNode) =>
+      map.set(
+        graphNode.nodeId,
+        graphNode.deps.map((y) => y.nodeId),
+      ),
+    new Map() as EdgesMap,
+  );
+
+  const pkgsInfoMap = depGraphData.pkgs.reduce(
+    (map, pkgInfo) => map.set(pkgInfo.id, pkgInfo.info),
+    new Map() as PkgsInfoMap,
+  );
+
+  return { nodesMap, edgesMap, pkgsInfoMap };
+}

--- a/src/cycles/index.ts
+++ b/src/cycles/index.ts
@@ -1,0 +1,4 @@
+import { cutCycles } from './cut-cycles';
+import { reconnectCycles } from './reconnect-cycles';
+
+export { cutCycles, reconnectCycles };

--- a/src/cycles/reconnect-cycles.ts
+++ b/src/cycles/reconnect-cycles.ts
@@ -1,0 +1,68 @@
+import { splitEdge } from './edges';
+import { DepGraph, DepGraphBuilder } from '..';
+import { eventLoopSpinner } from 'event-loop-spinner';
+import { getGraphMaps, EdgesMap } from './get-graph-maps';
+
+export async function reconnectCycles(depGraph: DepGraph) {
+  const { nodesMap, edgesMap, pkgsInfoMap } = getGraphMaps(depGraph);
+
+  const edgesToReconnect: EdgesMap = new Map();
+
+  const rootPkg = depGraph.rootPkg;
+  const depGraphBuilder = new DepGraphBuilder(depGraph.pkgManager, rootPkg);
+
+  for (const { nodeId, info, pkgId } of nodesMap.values()) {
+    if (nodeId === 'root-node') continue;
+    let nodeInfo = info;
+    if (info?.labels && info?.labels['removed-cyclic-deps']) {
+      const cyclicEdges = info.labels['removed-cyclic-deps'].split(',').sort();
+      if (!edgesToReconnect.has(nodeId)) edgesToReconnect.set(nodeId, []);
+      cyclicEdges.forEach((to) => edgesToReconnect.get(nodeId)!.push(to));
+      delete info.labels['removed-cyclic-deps'];
+      if (Object.keys(info.labels).length === 0) {
+        delete info.labels;
+      }
+      if (Object.keys(info).length === 0) {
+        nodeInfo = undefined;
+      }
+    }
+    depGraphBuilder.addPkgNode(pkgsInfoMap.get(pkgId)!, nodeId, nodeInfo);
+
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+  }
+
+  const edges: EdgesMap = new Map();
+
+  for (const [from, toNode] of edgesMap.entries()) {
+    if (!edges.has(from)) edges.set(from, []);
+    toNode.forEach((toNodeId) => edges.get(from)!.push(toNodeId));
+
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+  }
+
+  for (const [from, toNode] of edgesToReconnect.entries()) {
+    if (!edges.has(from)) edges.set(from, []);
+    toNode
+      .map(splitEdge)
+      .sort((a, b) => a.index - b.index)
+      .forEach(({ index, to }) => edges.get(from)!.splice(+index, 0, to));
+
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+  }
+
+  for (const [from, toArr] of edges.entries()) {
+    toArr.forEach((toNodeId) => depGraphBuilder.connectDep(from, toNodeId));
+
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+  }
+
+  return depGraphBuilder.build();
+}

--- a/test/core/stress.test.ts
+++ b/test/core/stress.test.ts
@@ -1,37 +1,11 @@
-import * as depGraphLib from '../../src';
-
-const dependencyName = 'needle';
-
-async function generateLargeGraph(width: number) {
-  const builder = new depGraphLib.DepGraphBuilder(
-    { name: 'npm' },
-    { name: 'root', version: '1.2.3' },
-  );
-  const rootNodeId = 'root-node';
-
-  const deepDependency = { name: dependencyName, version: '1.2.3' };
-
-  builder.addPkgNode(deepDependency, dependencyName);
-  builder.connectDep(rootNodeId, dependencyName);
-
-  for (let j = 0; j < width; j++) {
-    const shallowName = `id-${j}`;
-    const shallowDependency = { name: shallowName, version: '1.2.3' };
-
-    builder.addPkgNode(shallowDependency, shallowName);
-    builder.connectDep(rootNodeId, shallowName);
-    builder.connectDep(shallowName, dependencyName);
-  }
-
-  return builder.build();
-}
+import { generateLargeGraph } from '../helpers';
 
 describe('stress tests', () => {
-  test('pkgPathsToRoot() does not cause stack overflow for large dep-graphs', async () => {
-    const graph = await generateLargeGraph(125000);
+  test('pkgPathsToRoot() does not cause stack overflow for large dep-graphs', () => {
+    const graph = generateLargeGraph(125000);
 
     const result = graph.pkgPathsToRoot({
-      name: dependencyName,
+      name: 'needle',
       version: '1.2.3',
     });
     expect(result).toBeDefined();

--- a/test/cycles/__snapshots__/cut-cycles.test.ts.snap
+++ b/test/cycles/__snapshots__/cut-cycles.test.ts.snap
@@ -1,0 +1,2183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cut and reconnect cycles cyclic graph 1`] = `
+Object {
+  "graph": Object {
+    "nodes": Array [
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-0",
+          },
+        ],
+        "nodeId": "root-node",
+        "pkgId": "root@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-1",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-0",
+        "pkgId": "id-0@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-2",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-1",
+        "pkgId": "id-1@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-3",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-2",
+        "pkgId": "id-2@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-4",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-3",
+        "pkgId": "id-3@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-5",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-4",
+        "pkgId": "id-4@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-6",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-5",
+        "pkgId": "id-5@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-7",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-6",
+        "pkgId": "id-6@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-8",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-7",
+        "pkgId": "id-7@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "id-9",
+          },
+        ],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-8",
+        "pkgId": "id-8@1.2.3",
+      },
+      Object {
+        "deps": Array [],
+        "info": Object {
+          "labels": Object {
+            "removed-cyclic-deps": "0@@root-node",
+          },
+        },
+        "nodeId": "id-9",
+        "pkgId": "id-9@1.2.3",
+      },
+    ],
+    "rootNodeId": "root-node",
+  },
+  "pkgManager": Object {
+    "name": "npm",
+  },
+  "pkgs": Array [
+    Object {
+      "id": "root@1.2.3",
+      "info": Object {
+        "name": "root",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-0@1.2.3",
+      "info": Object {
+        "name": "id-0",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-1@1.2.3",
+      "info": Object {
+        "name": "id-1",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-2@1.2.3",
+      "info": Object {
+        "name": "id-2",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-3@1.2.3",
+      "info": Object {
+        "name": "id-3",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-4@1.2.3",
+      "info": Object {
+        "name": "id-4",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-5@1.2.3",
+      "info": Object {
+        "name": "id-5",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-6@1.2.3",
+      "info": Object {
+        "name": "id-6",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-7@1.2.3",
+      "info": Object {
+        "name": "id-7",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-8@1.2.3",
+      "info": Object {
+        "name": "id-8",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-9@1.2.3",
+      "info": Object {
+        "name": "id-9",
+        "version": "1.2.3",
+      },
+    },
+  ],
+  "schemaVersion": "1.2.0",
+}
+`;
+
+exports[`cut and reconnect cycles non cyclic graph 1`] = `
+Object {
+  "graph": Object {
+    "nodes": Array [
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+          Object {
+            "nodeId": "id-0",
+          },
+          Object {
+            "nodeId": "id-1",
+          },
+          Object {
+            "nodeId": "id-2",
+          },
+          Object {
+            "nodeId": "id-3",
+          },
+          Object {
+            "nodeId": "id-4",
+          },
+          Object {
+            "nodeId": "id-5",
+          },
+          Object {
+            "nodeId": "id-6",
+          },
+          Object {
+            "nodeId": "id-7",
+          },
+          Object {
+            "nodeId": "id-8",
+          },
+          Object {
+            "nodeId": "id-9",
+          },
+          Object {
+            "nodeId": "id-10",
+          },
+          Object {
+            "nodeId": "id-11",
+          },
+          Object {
+            "nodeId": "id-12",
+          },
+          Object {
+            "nodeId": "id-13",
+          },
+          Object {
+            "nodeId": "id-14",
+          },
+          Object {
+            "nodeId": "id-15",
+          },
+          Object {
+            "nodeId": "id-16",
+          },
+          Object {
+            "nodeId": "id-17",
+          },
+          Object {
+            "nodeId": "id-18",
+          },
+          Object {
+            "nodeId": "id-19",
+          },
+          Object {
+            "nodeId": "id-20",
+          },
+          Object {
+            "nodeId": "id-21",
+          },
+          Object {
+            "nodeId": "id-22",
+          },
+          Object {
+            "nodeId": "id-23",
+          },
+          Object {
+            "nodeId": "id-24",
+          },
+          Object {
+            "nodeId": "id-25",
+          },
+          Object {
+            "nodeId": "id-26",
+          },
+          Object {
+            "nodeId": "id-27",
+          },
+          Object {
+            "nodeId": "id-28",
+          },
+          Object {
+            "nodeId": "id-29",
+          },
+          Object {
+            "nodeId": "id-30",
+          },
+          Object {
+            "nodeId": "id-31",
+          },
+          Object {
+            "nodeId": "id-32",
+          },
+          Object {
+            "nodeId": "id-33",
+          },
+          Object {
+            "nodeId": "id-34",
+          },
+          Object {
+            "nodeId": "id-35",
+          },
+          Object {
+            "nodeId": "id-36",
+          },
+          Object {
+            "nodeId": "id-37",
+          },
+          Object {
+            "nodeId": "id-38",
+          },
+          Object {
+            "nodeId": "id-39",
+          },
+          Object {
+            "nodeId": "id-40",
+          },
+          Object {
+            "nodeId": "id-41",
+          },
+          Object {
+            "nodeId": "id-42",
+          },
+          Object {
+            "nodeId": "id-43",
+          },
+          Object {
+            "nodeId": "id-44",
+          },
+          Object {
+            "nodeId": "id-45",
+          },
+          Object {
+            "nodeId": "id-46",
+          },
+          Object {
+            "nodeId": "id-47",
+          },
+          Object {
+            "nodeId": "id-48",
+          },
+          Object {
+            "nodeId": "id-49",
+          },
+          Object {
+            "nodeId": "id-50",
+          },
+          Object {
+            "nodeId": "id-51",
+          },
+          Object {
+            "nodeId": "id-52",
+          },
+          Object {
+            "nodeId": "id-53",
+          },
+          Object {
+            "nodeId": "id-54",
+          },
+          Object {
+            "nodeId": "id-55",
+          },
+          Object {
+            "nodeId": "id-56",
+          },
+          Object {
+            "nodeId": "id-57",
+          },
+          Object {
+            "nodeId": "id-58",
+          },
+          Object {
+            "nodeId": "id-59",
+          },
+          Object {
+            "nodeId": "id-60",
+          },
+          Object {
+            "nodeId": "id-61",
+          },
+          Object {
+            "nodeId": "id-62",
+          },
+          Object {
+            "nodeId": "id-63",
+          },
+          Object {
+            "nodeId": "id-64",
+          },
+          Object {
+            "nodeId": "id-65",
+          },
+          Object {
+            "nodeId": "id-66",
+          },
+          Object {
+            "nodeId": "id-67",
+          },
+          Object {
+            "nodeId": "id-68",
+          },
+          Object {
+            "nodeId": "id-69",
+          },
+          Object {
+            "nodeId": "id-70",
+          },
+          Object {
+            "nodeId": "id-71",
+          },
+          Object {
+            "nodeId": "id-72",
+          },
+          Object {
+            "nodeId": "id-73",
+          },
+          Object {
+            "nodeId": "id-74",
+          },
+          Object {
+            "nodeId": "id-75",
+          },
+          Object {
+            "nodeId": "id-76",
+          },
+          Object {
+            "nodeId": "id-77",
+          },
+          Object {
+            "nodeId": "id-78",
+          },
+          Object {
+            "nodeId": "id-79",
+          },
+          Object {
+            "nodeId": "id-80",
+          },
+          Object {
+            "nodeId": "id-81",
+          },
+          Object {
+            "nodeId": "id-82",
+          },
+          Object {
+            "nodeId": "id-83",
+          },
+          Object {
+            "nodeId": "id-84",
+          },
+          Object {
+            "nodeId": "id-85",
+          },
+          Object {
+            "nodeId": "id-86",
+          },
+          Object {
+            "nodeId": "id-87",
+          },
+          Object {
+            "nodeId": "id-88",
+          },
+          Object {
+            "nodeId": "id-89",
+          },
+          Object {
+            "nodeId": "id-90",
+          },
+          Object {
+            "nodeId": "id-91",
+          },
+          Object {
+            "nodeId": "id-92",
+          },
+          Object {
+            "nodeId": "id-93",
+          },
+          Object {
+            "nodeId": "id-94",
+          },
+          Object {
+            "nodeId": "id-95",
+          },
+          Object {
+            "nodeId": "id-96",
+          },
+          Object {
+            "nodeId": "id-97",
+          },
+          Object {
+            "nodeId": "id-98",
+          },
+          Object {
+            "nodeId": "id-99",
+          },
+        ],
+        "nodeId": "root-node",
+        "pkgId": "root@1.2.3",
+      },
+      Object {
+        "deps": Array [],
+        "nodeId": "needle",
+        "pkgId": "needle@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-0",
+        "pkgId": "id-0@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-1",
+        "pkgId": "id-1@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-2",
+        "pkgId": "id-2@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-3",
+        "pkgId": "id-3@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-4",
+        "pkgId": "id-4@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-5",
+        "pkgId": "id-5@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-6",
+        "pkgId": "id-6@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-7",
+        "pkgId": "id-7@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-8",
+        "pkgId": "id-8@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-9",
+        "pkgId": "id-9@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-10",
+        "pkgId": "id-10@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-11",
+        "pkgId": "id-11@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-12",
+        "pkgId": "id-12@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-13",
+        "pkgId": "id-13@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-14",
+        "pkgId": "id-14@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-15",
+        "pkgId": "id-15@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-16",
+        "pkgId": "id-16@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-17",
+        "pkgId": "id-17@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-18",
+        "pkgId": "id-18@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-19",
+        "pkgId": "id-19@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-20",
+        "pkgId": "id-20@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-21",
+        "pkgId": "id-21@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-22",
+        "pkgId": "id-22@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-23",
+        "pkgId": "id-23@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-24",
+        "pkgId": "id-24@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-25",
+        "pkgId": "id-25@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-26",
+        "pkgId": "id-26@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-27",
+        "pkgId": "id-27@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-28",
+        "pkgId": "id-28@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-29",
+        "pkgId": "id-29@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-30",
+        "pkgId": "id-30@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-31",
+        "pkgId": "id-31@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-32",
+        "pkgId": "id-32@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-33",
+        "pkgId": "id-33@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-34",
+        "pkgId": "id-34@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-35",
+        "pkgId": "id-35@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-36",
+        "pkgId": "id-36@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-37",
+        "pkgId": "id-37@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-38",
+        "pkgId": "id-38@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-39",
+        "pkgId": "id-39@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-40",
+        "pkgId": "id-40@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-41",
+        "pkgId": "id-41@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-42",
+        "pkgId": "id-42@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-43",
+        "pkgId": "id-43@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-44",
+        "pkgId": "id-44@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-45",
+        "pkgId": "id-45@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-46",
+        "pkgId": "id-46@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-47",
+        "pkgId": "id-47@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-48",
+        "pkgId": "id-48@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-49",
+        "pkgId": "id-49@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-50",
+        "pkgId": "id-50@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-51",
+        "pkgId": "id-51@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-52",
+        "pkgId": "id-52@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-53",
+        "pkgId": "id-53@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-54",
+        "pkgId": "id-54@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-55",
+        "pkgId": "id-55@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-56",
+        "pkgId": "id-56@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-57",
+        "pkgId": "id-57@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-58",
+        "pkgId": "id-58@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-59",
+        "pkgId": "id-59@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-60",
+        "pkgId": "id-60@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-61",
+        "pkgId": "id-61@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-62",
+        "pkgId": "id-62@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-63",
+        "pkgId": "id-63@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-64",
+        "pkgId": "id-64@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-65",
+        "pkgId": "id-65@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-66",
+        "pkgId": "id-66@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-67",
+        "pkgId": "id-67@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-68",
+        "pkgId": "id-68@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-69",
+        "pkgId": "id-69@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-70",
+        "pkgId": "id-70@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-71",
+        "pkgId": "id-71@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-72",
+        "pkgId": "id-72@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-73",
+        "pkgId": "id-73@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-74",
+        "pkgId": "id-74@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-75",
+        "pkgId": "id-75@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-76",
+        "pkgId": "id-76@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-77",
+        "pkgId": "id-77@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-78",
+        "pkgId": "id-78@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-79",
+        "pkgId": "id-79@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-80",
+        "pkgId": "id-80@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-81",
+        "pkgId": "id-81@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-82",
+        "pkgId": "id-82@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-83",
+        "pkgId": "id-83@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-84",
+        "pkgId": "id-84@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-85",
+        "pkgId": "id-85@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-86",
+        "pkgId": "id-86@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-87",
+        "pkgId": "id-87@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-88",
+        "pkgId": "id-88@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-89",
+        "pkgId": "id-89@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-90",
+        "pkgId": "id-90@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-91",
+        "pkgId": "id-91@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-92",
+        "pkgId": "id-92@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-93",
+        "pkgId": "id-93@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-94",
+        "pkgId": "id-94@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-95",
+        "pkgId": "id-95@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-96",
+        "pkgId": "id-96@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-97",
+        "pkgId": "id-97@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-98",
+        "pkgId": "id-98@1.2.3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "needle",
+          },
+        ],
+        "nodeId": "id-99",
+        "pkgId": "id-99@1.2.3",
+      },
+    ],
+    "rootNodeId": "root-node",
+  },
+  "pkgManager": Object {
+    "name": "npm",
+  },
+  "pkgs": Array [
+    Object {
+      "id": "root@1.2.3",
+      "info": Object {
+        "name": "root",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "needle@1.2.3",
+      "info": Object {
+        "name": "needle",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-0@1.2.3",
+      "info": Object {
+        "name": "id-0",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-1@1.2.3",
+      "info": Object {
+        "name": "id-1",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-2@1.2.3",
+      "info": Object {
+        "name": "id-2",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-3@1.2.3",
+      "info": Object {
+        "name": "id-3",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-4@1.2.3",
+      "info": Object {
+        "name": "id-4",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-5@1.2.3",
+      "info": Object {
+        "name": "id-5",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-6@1.2.3",
+      "info": Object {
+        "name": "id-6",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-7@1.2.3",
+      "info": Object {
+        "name": "id-7",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-8@1.2.3",
+      "info": Object {
+        "name": "id-8",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-9@1.2.3",
+      "info": Object {
+        "name": "id-9",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-10@1.2.3",
+      "info": Object {
+        "name": "id-10",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-11@1.2.3",
+      "info": Object {
+        "name": "id-11",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-12@1.2.3",
+      "info": Object {
+        "name": "id-12",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-13@1.2.3",
+      "info": Object {
+        "name": "id-13",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-14@1.2.3",
+      "info": Object {
+        "name": "id-14",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-15@1.2.3",
+      "info": Object {
+        "name": "id-15",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-16@1.2.3",
+      "info": Object {
+        "name": "id-16",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-17@1.2.3",
+      "info": Object {
+        "name": "id-17",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-18@1.2.3",
+      "info": Object {
+        "name": "id-18",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-19@1.2.3",
+      "info": Object {
+        "name": "id-19",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-20@1.2.3",
+      "info": Object {
+        "name": "id-20",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-21@1.2.3",
+      "info": Object {
+        "name": "id-21",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-22@1.2.3",
+      "info": Object {
+        "name": "id-22",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-23@1.2.3",
+      "info": Object {
+        "name": "id-23",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-24@1.2.3",
+      "info": Object {
+        "name": "id-24",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-25@1.2.3",
+      "info": Object {
+        "name": "id-25",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-26@1.2.3",
+      "info": Object {
+        "name": "id-26",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-27@1.2.3",
+      "info": Object {
+        "name": "id-27",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-28@1.2.3",
+      "info": Object {
+        "name": "id-28",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-29@1.2.3",
+      "info": Object {
+        "name": "id-29",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-30@1.2.3",
+      "info": Object {
+        "name": "id-30",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-31@1.2.3",
+      "info": Object {
+        "name": "id-31",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-32@1.2.3",
+      "info": Object {
+        "name": "id-32",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-33@1.2.3",
+      "info": Object {
+        "name": "id-33",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-34@1.2.3",
+      "info": Object {
+        "name": "id-34",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-35@1.2.3",
+      "info": Object {
+        "name": "id-35",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-36@1.2.3",
+      "info": Object {
+        "name": "id-36",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-37@1.2.3",
+      "info": Object {
+        "name": "id-37",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-38@1.2.3",
+      "info": Object {
+        "name": "id-38",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-39@1.2.3",
+      "info": Object {
+        "name": "id-39",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-40@1.2.3",
+      "info": Object {
+        "name": "id-40",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-41@1.2.3",
+      "info": Object {
+        "name": "id-41",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-42@1.2.3",
+      "info": Object {
+        "name": "id-42",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-43@1.2.3",
+      "info": Object {
+        "name": "id-43",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-44@1.2.3",
+      "info": Object {
+        "name": "id-44",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-45@1.2.3",
+      "info": Object {
+        "name": "id-45",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-46@1.2.3",
+      "info": Object {
+        "name": "id-46",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-47@1.2.3",
+      "info": Object {
+        "name": "id-47",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-48@1.2.3",
+      "info": Object {
+        "name": "id-48",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-49@1.2.3",
+      "info": Object {
+        "name": "id-49",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-50@1.2.3",
+      "info": Object {
+        "name": "id-50",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-51@1.2.3",
+      "info": Object {
+        "name": "id-51",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-52@1.2.3",
+      "info": Object {
+        "name": "id-52",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-53@1.2.3",
+      "info": Object {
+        "name": "id-53",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-54@1.2.3",
+      "info": Object {
+        "name": "id-54",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-55@1.2.3",
+      "info": Object {
+        "name": "id-55",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-56@1.2.3",
+      "info": Object {
+        "name": "id-56",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-57@1.2.3",
+      "info": Object {
+        "name": "id-57",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-58@1.2.3",
+      "info": Object {
+        "name": "id-58",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-59@1.2.3",
+      "info": Object {
+        "name": "id-59",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-60@1.2.3",
+      "info": Object {
+        "name": "id-60",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-61@1.2.3",
+      "info": Object {
+        "name": "id-61",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-62@1.2.3",
+      "info": Object {
+        "name": "id-62",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-63@1.2.3",
+      "info": Object {
+        "name": "id-63",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-64@1.2.3",
+      "info": Object {
+        "name": "id-64",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-65@1.2.3",
+      "info": Object {
+        "name": "id-65",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-66@1.2.3",
+      "info": Object {
+        "name": "id-66",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-67@1.2.3",
+      "info": Object {
+        "name": "id-67",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-68@1.2.3",
+      "info": Object {
+        "name": "id-68",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-69@1.2.3",
+      "info": Object {
+        "name": "id-69",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-70@1.2.3",
+      "info": Object {
+        "name": "id-70",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-71@1.2.3",
+      "info": Object {
+        "name": "id-71",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-72@1.2.3",
+      "info": Object {
+        "name": "id-72",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-73@1.2.3",
+      "info": Object {
+        "name": "id-73",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-74@1.2.3",
+      "info": Object {
+        "name": "id-74",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-75@1.2.3",
+      "info": Object {
+        "name": "id-75",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-76@1.2.3",
+      "info": Object {
+        "name": "id-76",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-77@1.2.3",
+      "info": Object {
+        "name": "id-77",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-78@1.2.3",
+      "info": Object {
+        "name": "id-78",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-79@1.2.3",
+      "info": Object {
+        "name": "id-79",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-80@1.2.3",
+      "info": Object {
+        "name": "id-80",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-81@1.2.3",
+      "info": Object {
+        "name": "id-81",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-82@1.2.3",
+      "info": Object {
+        "name": "id-82",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-83@1.2.3",
+      "info": Object {
+        "name": "id-83",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-84@1.2.3",
+      "info": Object {
+        "name": "id-84",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-85@1.2.3",
+      "info": Object {
+        "name": "id-85",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-86@1.2.3",
+      "info": Object {
+        "name": "id-86",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-87@1.2.3",
+      "info": Object {
+        "name": "id-87",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-88@1.2.3",
+      "info": Object {
+        "name": "id-88",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-89@1.2.3",
+      "info": Object {
+        "name": "id-89",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-90@1.2.3",
+      "info": Object {
+        "name": "id-90",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-91@1.2.3",
+      "info": Object {
+        "name": "id-91",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-92@1.2.3",
+      "info": Object {
+        "name": "id-92",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-93@1.2.3",
+      "info": Object {
+        "name": "id-93",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-94@1.2.3",
+      "info": Object {
+        "name": "id-94",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-95@1.2.3",
+      "info": Object {
+        "name": "id-95",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-96@1.2.3",
+      "info": Object {
+        "name": "id-96",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-97@1.2.3",
+      "info": Object {
+        "name": "id-97",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-98@1.2.3",
+      "info": Object {
+        "name": "id-98",
+        "version": "1.2.3",
+      },
+    },
+    Object {
+      "id": "id-99@1.2.3",
+      "info": Object {
+        "name": "id-99",
+        "version": "1.2.3",
+      },
+    },
+  ],
+  "schemaVersion": "1.2.0",
+}
+`;

--- a/test/cycles/cut-cycles.test.ts
+++ b/test/cycles/cut-cycles.test.ts
@@ -1,0 +1,49 @@
+import { cutCycles } from '../../src/cycles/cut-cycles';
+import { reconnectCycles } from '../../src/cycles/reconnect-cycles';
+import * as depGraphLib from '../../src';
+import { DepGraph, PkgInfo } from '../../src';
+import { generateLargeGraph } from '../helpers';
+import { NodeId } from '../../src/cycles/get-graph-maps';
+
+describe('cut and reconnect cycles', () => {
+  const cyclicDepGraph = generateDepGraphWithCycles(10);
+  const nonCyclicDepGraph = generateLargeGraph(100);
+
+  it('cyclic graph', async () => validate(cyclicDepGraph));
+
+  it('non cyclic graph', async () => validate(nonCyclicDepGraph));
+});
+
+async function validate(depGraph: DepGraph) {
+  const depGraphWithoutCycles = await cutCycles(depGraph);
+  expect(depGraphWithoutCycles.toJSON()).toMatchSnapshot();
+
+  const revertedDepGraph = await reconnectCycles(depGraphWithoutCycles);
+  expect(depGraph.toJSON()).toEqual(revertedDepGraph.toJSON());
+}
+
+function generateDepGraphWithCycles(numberOfCycles: number): DepGraph {
+  // This creates a graph where each node is a child of the previous node and also connected to the root node
+  // I.e. Root, A, B,c : Root -> A, A -> Root, A -> B, B -> Root, B -> C, B -> Root
+  // Total of 3 cycles: Root->A->Root, Root->A->B->Root, Root->A->B->C->Root
+  const builder = new depGraphLib.DepGraphBuilder(
+    { name: 'npm' },
+    { name: 'root', version: '1.2.3' },
+  );
+  const rootNodeId: NodeId = 'root-node';
+
+  let lastNodeId: NodeId = rootNodeId;
+
+  for (let j = 0; j < numberOfCycles; j++) {
+    const newNodeId: NodeId = `id-${j}`;
+    const newNodePkgInfo: PkgInfo = { name: newNodeId, version: '1.2.3' };
+
+    builder.addPkgNode(newNodePkgInfo, newNodeId);
+    builder.connectDep(lastNodeId, newNodeId);
+    builder.connectDep(newNodeId, rootNodeId);
+
+    lastNodeId = newNodeId;
+  }
+
+  return builder.build();
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,7 @@
 import * as _isEqual from 'lodash.isequal';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as depGraphLib from '../src';
 import { PkgInfo } from '../src';
 
 export function loadFixture(name: string) {
@@ -80,3 +81,29 @@ export const sortBy = (arr: any[], p: string) =>
       return 0;
     }
   });
+
+export function generateLargeGraph(width: number) {
+  const dependencyName = 'needle';
+
+  const builder = new depGraphLib.DepGraphBuilder(
+    { name: 'npm' },
+    { name: 'root', version: '1.2.3' },
+  );
+  const rootNodeId = 'root-node';
+
+  const deepDependency = { name: dependencyName, version: '1.2.3' };
+
+  builder.addPkgNode(deepDependency, dependencyName);
+  builder.connectDep(rootNodeId, dependencyName);
+
+  for (let j = 0; j < width; j++) {
+    const shallowName = `id-${j}`;
+    const shallowDependency = { name: shallowName, version: '1.2.3' };
+
+    builder.addPkgNode(shallowDependency, shallowName);
+    builder.connectDep(rootNodeId, shallowName);
+    builder.connectDep(shallowName, dependencyName);
+  }
+
+  return builder.build();
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds `removeCycles` and `addCyclesBack` functionality.
Those are 2 separate functions that needs to be imported like
```ts
import { removeCycles, addCyclesBack } from '@snyk/dep-graph/cycles' ;
```

Removing cycles iterates over the nodes * number of cycles
The worst case is where every node in the graph creates a cycle, in that case it will take `2 + 3 + 4 + ... + N` iterations, which is (N(N-1))/2, which is O(N^2)

For more trivial graphs, 1000 cycles for example, it takes about 200ms to remove all cycles. ( ±O(N) )

Removing a cycles adds the edge (and its index) as a label to the node that this edge was removed from.
Adding all the cycles back creates an identical DepGraph to the first graph, so
```ts
  const revertedDepGraph = addCyclesBack(removeCycles(depGraph));
  assert.deepEqual(depGraph.toJSON(), revertedDepGraph.toJSON()); // ok
```