### PR TITLE
feat: deduplicate cycles in graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 coverage/
 package-lock.json
+.idea

--- a/src/core/builder.ts
+++ b/src/core/builder.ts
@@ -22,7 +22,7 @@ class DepGraphBuilder {
   private _rootNodeId: string;
   private _rootPkgId: string;
 
-  public constructor(pkgManager: types.PkgManager, rootPkg?: types.PkgInfo) {
+  public constructor(pkgManager: types.PkgManager, rootPkg?: types.PkgInfo, rootNodeId?: string) {
     const graph = new graphlib.Graph({
       directed: true,
       multigraph: false,
@@ -35,7 +35,7 @@ class DepGraphBuilder {
       };
     }
 
-    this._rootNodeId = 'root-node';
+    this._rootNodeId = rootNodeId || 'root-node';
     this._rootPkgId = DepGraphBuilder._getPkgId(rootPkg);
     this._pkgs[this._rootPkgId] = rootPkg;
 

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -2,10 +2,11 @@ import * as crypto from 'crypto';
 import * as types from '../core/types';
 import { DepGraphBuilder } from '../core/builder';
 import { EventLoopSpinner } from './event-loop-spinner';
+import { mapToNonCyclicGraph } from './map-to-non-cylic-graph';
 
 import objectHash = require('object-hash');
 
-export { depTreeToGraph, graphToDepTree, DepTree };
+export { depTreeToGraph, graphToDepTree, DepTree, mapToNonCyclicGraph };
 
 interface DepTreeDep {
   name?: string; // shouldn't, but might happen

--- a/src/legacy/map-to-non-cylic-graph.ts
+++ b/src/legacy/map-to-non-cylic-graph.ts
@@ -1,0 +1,80 @@
+import { DepGraph, DepGraphBuilder, PkgInfo } from '..';
+import { DepGraphInternal, NodeInfo } from '../core/types';
+import { EventLoopSpinner } from './event-loop-spinner';
+
+type NodeId = string;
+
+export async function mapToNonCyclicGraph(
+  depGraphToMap: DepGraph,
+): Promise<DepGraph> {
+  const depGraph = depGraphToMap as DepGraphInternal;
+  if (!depGraph.hasCycles()) {
+    return depGraph;
+  }
+
+  const depGraphBuilder = new DepGraphBuilder(
+    depGraph.pkgManager,
+    depGraph.rootPkg,
+    depGraph.rootNodeId
+  );
+
+  const eventLoopSpinner = new EventLoopSpinner();
+
+  await dfsBuildGraph(
+    depGraph.rootNodeId,
+    depGraph,
+    depGraphBuilder,
+    eventLoopSpinner,
+  );
+
+  return depGraphBuilder.build();
+}
+
+async function dfsBuildGraph(
+  nodeId: NodeId,
+  depGraph: DepGraphInternal,
+  depGraphBuilder: DepGraphBuilder,
+  eventLoopSpinner: EventLoopSpinner,
+  ancestors: NodeId[] = [],
+  memoizationSet: Set<NodeId> = new Set(),
+): Promise<void> {
+  const parentNodeId = ancestors[ancestors.length - 1];
+  const pkgInfo: PkgInfo = depGraph.getNodePkg(nodeId);
+  let nodeInfo: NodeInfo = depGraph.getNode(nodeId);
+  let dependencies = depGraph.getNodeDepsNodeIds(nodeId);
+
+  if (ancestors.includes(nodeId)) {
+    nodeId = `${nodeId}_pruned`;
+    nodeInfo = {
+      ...(nodeInfo || {}),
+      labels: {
+        ...(nodeInfo.labels || {}),
+        pruned: 'cyclic',
+      },
+    };
+    dependencies = [];
+  } else if (memoizationSet.has(nodeId)) {
+    dependencies = [];
+  }
+
+  if (parentNodeId) {
+    depGraphBuilder.addPkgNode(pkgInfo, nodeId, nodeInfo);
+    depGraphBuilder.connectDep(parentNodeId, nodeId);
+  }
+
+  for (const dep of dependencies) {
+    await dfsBuildGraph(
+      dep,
+      depGraph,
+      depGraphBuilder,
+      eventLoopSpinner,
+      ancestors.concat(nodeId),
+      memoizationSet
+    );
+  }
+
+  memoizationSet.add(nodeId);
+  if (eventLoopSpinner.isStarving()) {
+    await eventLoopSpinner.spin();
+  }
+}

--- a/test/cycles/__snapshots__/to-non-cyclic-graph.test.ts.snap
+++ b/test/cycles/__snapshots__/to-non-cyclic-graph.test.ts.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mapToNonCyclicGraph cyclic graph should return a non-cyclic graph - snapshot 1`] = `
+Object {
+  "graph": Object {
+    "nodes": Array [
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "foo@2|x",
+          },
+        ],
+        "nodeId": "toor",
+        "pkgId": "toor@1.0.0",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "bar@3|x",
+          },
+        ],
+        "nodeId": "foo@2|x",
+        "pkgId": "foo@2",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "baz@4|x",
+          },
+        ],
+        "nodeId": "bar@3|x",
+        "pkgId": "bar@3",
+      },
+      Object {
+        "deps": Array [
+          Object {
+            "nodeId": "foo@2|x_pruned",
+          },
+        ],
+        "nodeId": "baz@4|x",
+        "pkgId": "baz@4",
+      },
+      Object {
+        "deps": Array [],
+        "info": Object {
+          "labels": Object {
+            "pruned": "cyclic",
+          },
+        },
+        "nodeId": "foo@2|x_pruned",
+        "pkgId": "foo@2",
+      },
+    ],
+    "rootNodeId": "toor",
+  },
+  "pkgManager": Object {
+    "name": "pip",
+  },
+  "pkgs": Array [
+    Object {
+      "id": "toor@1.0.0",
+      "info": Object {
+        "name": "toor",
+        "version": "1.0.0",
+      },
+    },
+    Object {
+      "id": "foo@2",
+      "info": Object {
+        "name": "foo",
+        "version": "2",
+      },
+    },
+    Object {
+      "id": "bar@3",
+      "info": Object {
+        "name": "bar",
+        "version": "3",
+      },
+    },
+    Object {
+      "id": "baz@4",
+      "info": Object {
+        "name": "baz",
+        "version": "4",
+      },
+    },
+  ],
+  "schemaVersion": "1.2.0",
+}
+`;

--- a/test/cycles/to-non-cyclic-graph.test.ts
+++ b/test/cycles/to-non-cyclic-graph.test.ts
@@ -1,0 +1,52 @@
+import * as depGraphLib from '../../src';
+import * as helpers from '../helpers';
+import { mapToNonCyclicGraph } from '../../src/legacy';
+import { DepGraphInternal } from '../../src/core/types';
+import { DepGraph, DepGraphData } from '../../src';
+
+describe('mapToNonCyclicGraph', () => {
+  describe('cyclic graph', () => {
+    let cyclicDepGraphData: DepGraphData;
+    let cyclicDepGraph: DepGraph;
+    let nonCyclicDepGraph: DepGraphInternal;
+
+    beforeEach(async () => {
+      cyclicDepGraphData = helpers.loadFixture('cyclic-dep-graph.json');
+      cyclicDepGraph = depGraphLib.createFromJSON(cyclicDepGraphData);
+
+      nonCyclicDepGraph = (await depGraphLib.legacy.mapToNonCyclicGraph(
+        cyclicDepGraph,
+      )) as DepGraphInternal;
+    });
+
+    test('should not change original depGraph', async () => {
+      const initialDepGraphData = helpers.loadFixture('cyclic-dep-graph.json');
+
+      expect(cyclicDepGraph.toJSON()).toEqual(initialDepGraphData);
+    });
+
+    test('should return a non-cyclic graph', async () => {
+      expect(nonCyclicDepGraph.hasCycles()).toBeFalsy();
+    });
+
+    test('should return a cyclic graph with "more or equal" nodes number', async () => {
+      expect(nonCyclicDepGraph.getDepPkgs().length).toBeGreaterThanOrEqual(
+        cyclicDepGraph.getDepPkgs().length,
+      );
+    });
+
+    test('should return a non-cyclic graph - snapshot', async () => {
+      expect(nonCyclicDepGraph).toMatchSnapshot();
+    });
+  });
+
+  test('should return the same graph for non-cyclic graph', async () => {
+    const nonCyclicDepGraphData = helpers.loadFixture('goof-graph.json');
+    const cyclicDepGraph = depGraphLib.createFromJSON(nonCyclicDepGraphData);
+
+    const resultDepGraph = (await depGraphLib.legacy.mapToNonCyclicGraph(
+      cyclicDepGraph,
+    )) as DepGraphInternal;
+    expect(resultDepGraph).toStrictEqual(cyclicDepGraph);
+  });
+});

--- a/test/fixtures/memoization-cyclic-dep-graph.json
+++ b/test/fixtures/memoization-cyclic-dep-graph.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "pip"
+  },
+  "pkgs": [
+    {
+      "id": "toor@1.0.0",
+      "info": {
+        "name": "toor",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "foo@2",
+      "info": {
+        "name": "foo",
+        "version": "2"
+      }
+    },
+    {
+      "id": "bar@3",
+      "info": {
+        "name": "bar",
+        "version": "3"
+      }
+    },
+    {
+      "id": "baz@4",
+      "info": {
+        "name": "baz",
+        "version": "4"
+      }
+    },
+    {
+      "id": "aaa@5",
+      "info": {
+        "name": "aaa",
+        "version": "5"
+      }
+    },
+    {
+      "id": "bbb@6",
+      "info": {
+        "name": "bbb",
+        "version": "6"
+      }
+    },
+    {
+      "id": "ccc@7",
+      "info": {
+        "name": "ccc",
+        "version": "7"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "toor",
+    "nodes": [
+      {
+        "nodeId": "toor",
+        "pkgId": "toor@1.0.0",
+        "deps": [
+          { "nodeId": "foo@2|x" },
+          { "nodeId": "aaa@5|x" },
+          { "nodeId": "ccc@7|x" }
+        ]
+      },
+      {
+        "nodeId": "foo@2|x",
+        "pkgId": "foo@2",
+        "deps": [
+          {
+            "nodeId": "bar@3|x"
+          }
+        ]
+      },
+      {
+        "nodeId": "bar@3|x",
+        "pkgId": "bar@3",
+        "deps": [
+          {
+            "nodeId": "baz@4|x"
+          }
+        ]
+      },
+      {
+        "nodeId": "baz@4|x",
+        "pkgId": "baz@4",
+        "deps": [
+          {
+            "nodeId": "foo@2|x"
+          }
+        ]
+      },
+      {
+        "nodeId": "aaa@5|x",
+        "pkgId": "aaa@5",
+        "deps": [
+          {
+            "nodeId": "bbb@6|x"
+          }
+        ]
+      },
+      {
+        "nodeId": "bbb@6|x",
+        "pkgId": "bbb@6",
+        "deps": []
+      },
+      {
+        "nodeId": "ccc@7|x",
+        "pkgId": "ccc@7",
+        "deps": [
+          {
+            "nodeId": "aaa@5|x"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/memoization-dep-graph.json
+++ b/test/fixtures/memoization-dep-graph.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "pip"
+  },
+  "pkgs": [
+    {
+      "id": "toor@1.0.0",
+      "info": {
+        "name": "toor",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "aaa@5",
+      "info": {
+        "name": "aaa",
+        "version": "5"
+      }
+    },
+    {
+      "id": "bbb@6",
+      "info": {
+        "name": "bbb",
+        "version": "6"
+      }
+    },
+    {
+      "id": "ccc@7",
+      "info": {
+        "name": "ccc",
+        "version": "7"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "toor",
+    "nodes": [
+      {
+        "nodeId": "toor",
+        "pkgId": "toor@1.0.0",
+        "deps": [
+          { "nodeId": "aaa@5|x" },
+          { "nodeId": "ccc@7|x" }
+        ]
+      },
+      {
+        "nodeId": "aaa@5|x",
+        "pkgId": "aaa@5",
+        "deps": [
+          {
+            "nodeId": "bbb@6|x"
+          }
+        ]
+      },
+      {
+        "nodeId": "bbb@6|x",
+        "pkgId": "bbb@6",
+        "deps": []
+      },
+      {
+        "nodeId": "ccc@7|x",
+        "pkgId": "ccc@7",
+        "deps": [
+          {
+            "nodeId": "aaa@5|x"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/legacy/__snapshots__/to-dep-tree.test.ts.snap
+++ b/test/legacy/__snapshots__/to-dep-tree.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`graphs with cycles are supported 1`] = `
+Object {
+  "dependencies": Object {
+    "foo": Object {
+      "dependencies": Object {
+        "bar": Object {
+          "dependencies": Object {
+            "baz": Object {
+              "labels": Object {
+                "pruned": "cyclic",
+              },
+              "name": "baz",
+              "version": "4",
+            },
+          },
+          "name": "bar",
+          "version": "3",
+        },
+      },
+      "name": "foo",
+      "version": "2",
+    },
+  },
+  "name": "toor",
+  "packageFormatVersion": "pip:0.0.1",
+  "type": "pip",
+  "version": "1.0.0",
+}
+`;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
new `mapToNonCyclicGraph` function that takes a cyclic depgraph and returns a new instance of a depGraph with the cycles pruned.