### PR TITLE
feat: expose packages that have been added in builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 coverage/
 package-lock.json
+.idea/

--- a/src/core/builder.ts
+++ b/src/core/builder.ts
@@ -46,6 +46,10 @@ class DepGraphBuilder {
     this._pkgManager = pkgManager;
   }
 
+  public getPkgs(): types.PkgInfo[] {
+    return Object.values(this._pkgs);
+  }
+
   // TODO: this can create disconnected nodes
   public addPkgNode(
     pkgInfo: types.PkgInfo,

--- a/test/core/builder.test.ts
+++ b/test/core/builder.test.ts
@@ -1,14 +1,76 @@
 import { DepGraphBuilder } from '../../src';
 
-describe('empty graph', () => {
-  const builder = new DepGraphBuilder({ name: 'pip' });
+describe('builder', () => {
+  let builder;
 
-  const depGraph = builder.build();
+  beforeEach(() => {
+    builder = new DepGraphBuilder({ name: 'poetry' });
+  });
 
-  test('use it', async () => {
-    expect(depGraph.pkgManager.name).toEqual('pip');
+  test('empty graph', async () => {
+    const depGraph = builder.build();
+    expect(depGraph.pkgManager.name).toEqual('poetry');
     expect(depGraph.rootPkg).toHaveProperty('name');
     expect(depGraph.getPkgs()).toHaveLength(1);
     expect(depGraph.getDepPkgs()).toHaveLength(0);
+  });
+
+  describe('when using addPkgNode', () => {
+    it('should throw error if trying to add root node in dependencies', () => {
+      const pkgToAdd = { name: 'json' };
+      expect(() => {
+        builder.addPkgNode(pkgToAdd, 'root-node');
+      }).toThrow(Error);
+    });
+
+    it('should add the package to the relevant properties and graph', () => {
+      const pkgToAdd = { name: 'json', version: '1.0.0' };
+      builder.addPkgNode(pkgToAdd, pkgToAdd.name);
+
+      const packageAdded = builder
+        .getPkgs()
+        .find(
+          (pkg) =>
+            pkg.name === pkgToAdd.name && pkg.version === pkgToAdd.version,
+        );
+      expect(packageAdded).toBeDefined();
+    });
+  });
+
+  describe('when using connectDep', () => {
+    const parentDepNodeId = 'parent-dep';
+    const childDepNodeId = 'child-dep';
+
+    beforeEach(() => {
+      const parentPkg = { name: 'parent-dep', version: '1.0.0' };
+      const childPkg = { name: 'child-dep', version: '1.0.0' };
+      builder.addPkgNode(parentPkg, parentDepNodeId);
+      builder.addPkgNode(childPkg, childDepNodeId);
+    });
+
+    it('should throw an error if the parent node does not exist', () => {
+      expect(() => {
+        builder.connectDep('non-existent-dep', childDepNodeId);
+      }).toThrow(Error);
+    });
+
+    it('should throw an error if the child node does not exist', () => {
+      expect(() => {
+        builder.connectDep(parentDepNodeId, 'non-existent-dep');
+      }).toThrow(Error);
+    });
+
+    it('should connect two dependencies in graph', () => {
+      builder.connectDep(parentDepNodeId, childDepNodeId);
+      const actualGraph = builder.build();
+      const graphJson = actualGraph.toJSON().graph;
+      const parentDepInGraph = graphJson.nodes.find(
+        (dep) => dep.nodeId === parentDepNodeId,
+      );
+      expect(parentDepInGraph.deps.length).toBe(1);
+      expect(
+        parentDepInGraph.deps.find((dep) => dep.nodeId === childDepNodeId),
+      ).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Exposes `DepGraphBuilder._pkgs` using public get property `packages`. 

#### Any background context you want to provide?
Poetry lockfiles can have circular dependencies. In an effort to fix a bug that arose out of this in `snyk-poetry-lockfile-parser` repo, I found a need to access the packages that have already been added.
To see the packages already added, consumers of `DepGraphBuilder` have to keep a local record of the packages added or alternatively call `build`.