### PR TITLE
fix: Add some minimal function docs

### DIFF
--- a/src/core/create-from-json.ts
+++ b/src/core/create-from-json.ts
@@ -9,6 +9,10 @@ import { DepGraphImpl } from './dep-graph';
 
 export const SUPPORTED_SCHEMA_RANGE = '^1.0.0';
 
+/**
+ * Create a DepGraph instance from a JSON representation of a dep graph. This
+ * is typically used after passing the graph over the wire as `DepGraphData`.
+ */
 export function createFromJSON(depGraphData: DepGraphData): DepGraph {
   validateDepGraphData(depGraphData);
 

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -64,10 +64,16 @@ class DepGraphImpl implements types.DepGraphInternal {
     return this._rootNodeId;
   }
 
+  /**
+   * Get all unique packages in the graph (including the root package)
+   */
   public getPkgs(): types.PkgInfo[] {
     return this._pkgList;
   }
 
+  /**
+   * Get all unique packages in the graph (excluding the root package)
+   */
   public getDepPkgs(): types.PkgInfo[] {
     return this._depPkgsList;
   }
@@ -199,6 +205,10 @@ class DepGraphImpl implements types.DepGraphInternal {
     return nodes.map((node) => this.getNodePkg(node));
   }
 
+  /**
+   * Create a JSON representation of a dep graph. This is typically used to
+   * send the dep graph over the wire
+   */
   public toJSON(): types.DepGraphData {
     const nodeIds = this._graph.nodes();
 


### PR DESCRIPTION
There are a few places where the dep graph function names are not quite enough to explain the intent / usages (or at least, I could not easily understand)

This patch adds some small docstrings so that IDEs can show them, rather than needing to open the dep graph source / docs.