### PR TITLE
feat: upgrade semver to 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash.union": "^4.6.0",
     "lodash.values": "^4.3.0",
     "object-hash": "^2.0.3",
-    "semver": "^6.0.0",
+    "semver": "^7.0.0",
     "tslib": "^1.13.0"
   }
 }


### PR DESCRIPTION
https://github.com/npm/node-semver/blob/master/CHANGELOG.md#700

> Refactor module into separate files for better tree-shaking
> Drop support for very old node versions, use const/let, => functions, and classes.

I believe this drops support for node 0.x.
