### PR TITLE
feat: remove lodash.has

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 coverage/
 package-lock.json
 .idea/
+benchmark/
+isolate-*

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "lodash.constant": "^3.0.0",
     "lodash.filter": "^4.6.0",
     "lodash.foreach": "^4.5.0",
-    "lodash.has": "^4.5.2",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lodash.isfunction": "^3.0.9",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/semver": "^7",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
+    "benny": "^3.6.15",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "jest": "^26",

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -1,0 +1,16 @@
+const { createFromJSON } = require('../dist');
+
+const b = require('benny');
+const fs = require('fs');
+
+const doc = JSON.parse(fs.readFileSync(process.argv[2], { encoding: 'utf-8' }));
+
+b.suite(
+  'createFromJSON',
+
+  b.add('parsing arg', () => createFromJSON(doc)),
+
+  b.cycle(),
+  b.complete(),
+  b.save({ file: 'reduce', version: '1.0.0' }),
+);

--- a/src/graphlib/alg/dfs.ts
+++ b/src/graphlib/alg/dfs.ts
@@ -1,5 +1,4 @@
 import * as each from 'lodash.foreach';
-import * as has from 'lodash.has';
 import { Graph } from '../graph';
 
 /*
@@ -29,8 +28,8 @@ export function dfs(g: Graph, vs: string[], order: 'pre' | 'post'): string[] {
   return acc;
 }
 
-function doDfs(g, v, postorder, visited, navigation, acc) {
-  if (!has(visited, v)) {
+function doDfs(g, v: string, postorder, visited, navigation, acc) {
+  if (!(v in visited)) {
     visited[v] = true;
 
     if (!postorder) {

--- a/src/graphlib/alg/topsort.ts
+++ b/src/graphlib/alg/topsort.ts
@@ -1,5 +1,4 @@
 import * as each from 'lodash.foreach';
-import * as has from 'lodash.has';
 import * as size from 'lodash.size';
 
 import { Graph } from '../graph';
@@ -9,12 +8,12 @@ export function topsort(g: Graph): string[] {
   const stack = {};
   const results: any[] = [];
 
-  function visit(node) {
-    if (has(stack, node)) {
+  function visit(node: string) {
+    if (node in stack) {
       throw new CycleException();
     }
 
-    if (!has(visited, node)) {
+    if (!(node in visited)) {
       stack[node] = true;
       visited[node] = true;
       each(g.predecessors(node), visit);

--- a/src/graphlib/graph.ts
+++ b/src/graphlib/graph.ts
@@ -3,7 +3,6 @@
 import * as constant from 'lodash.constant';
 import * as each from 'lodash.foreach';
 import * as _filter from 'lodash.foreach';
-import * as has from 'lodash.has';
 import * as isEmpty from 'lodash.isempty';
 import * as isFunction from 'lodash.isfunction';
 import * as isUndefined from 'lodash.isundefined';
@@ -48,7 +47,7 @@ export class Graph {
   _defaultNodeLabelFn;
   _defaultEdgeLabelFn;
 
-  _nodes;
+  _nodes: { [key: string]: unknown };
 
   _parent;
   _children;
@@ -58,12 +57,12 @@ export class Graph {
   _out;
   _sucs;
   _edgeObjs;
-  _edgeLabels;
+  _edgeLabels: { [key: string]: unknown };
 
   constructor(opts: GraphOptions) {
-    this._isDirected = has(opts, 'directed') ? opts.directed : true;
-    this._isMultigraph = has(opts, 'multigraph') ? opts.multigraph : false;
-    this._isCompound = has(opts, 'compound') ? opts.compound : false;
+    this._isDirected = opts?.directed ?? true;
+    this._isMultigraph = opts?.multigraph ?? false;
+    this._isCompound = opts?.compound ?? false;
 
     // Label for the graph itself
     this._label = undefined;
@@ -180,7 +179,7 @@ export class Graph {
   }
 
   setNode(v, value?) {
-    if (has(this._nodes, v)) {
+    if (v in this._nodes) {
       if (arguments.length > 1) {
         this._nodes[v] = value;
       }
@@ -206,12 +205,12 @@ export class Graph {
   }
 
   hasNode(v: string): boolean {
-    return has(this._nodes, v);
+    return v in this._nodes;
   }
 
   removeNode(v) {
     const self = this;
-    if (has(this._nodes, v)) {
+    if (v in this._nodes) {
       const removeEdge = function (e) {
         self.removeEdge(self._edgeObjs[e]);
       };
@@ -446,7 +445,7 @@ export class Graph {
     }
 
     const e = edgeArgsToId(this._isDirected, v, w, name);
-    if (has(this._edgeLabels, e)) {
+    if (e in this._edgeLabels) {
       if (valueSpecified) {
         this._edgeLabels[e] = value;
       }
@@ -494,7 +493,7 @@ export class Graph {
       arguments.length === 1
         ? edgeObjToId(this._isDirected, arguments[0])
         : edgeArgsToId(this._isDirected, v, w, name);
-    return has(this._edgeLabels, e);
+    return e in this._edgeLabels;
   }
 
   removeEdge(v, w?, name?) {


### PR DESCRIPTION
#### What does this PR do?

Indiscriminately replace `lodash.has` with `in`. This is a 40% speedup for loading a graph.

Most of the top profiling entries are related to `lodash.has`:
```
 [JavaScript]:
   ticks  total  nonlib   name
    107    2.0%   11.5%  RegExp: \.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]
     69    1.3%    7.4%  RegExp: ^\w*$
     65    1.2%    7.0%  *createFromJSON dist/core/create-from-json.js:13:24
     50    0.9%    5.4%  *hasPath nm/lodash.has/index.js:551:17
     50    0.9%    5.4%  *<anonymous> dist/graphlib/alg/dfs.js:35:38
     37    0.7%    4.0%  *setEdge dist/graphlib/graph.js:323:12
     21    0.4%    2.3%  *successors dist/graphlib/graph.js:233:15
     12    0.2%    1.3%  *isKey nm/lodash.has/index.js:596:15
     11    0.2%    1.2%  *<anonymous> dist/core/validate-graph.js:16:48
     10    0.2%    1.1%  *getMapData nm/lodash.has/index.js:522:20
      9    0.2%    1.0%  *<anonymous> dist/core/create-from-json.js:71:26
      5    0.1%    0.5%  *edgeArgsToId dist/graphlib/graph.js:455:22
      4    0.1%    0.4%  *<anonymous> dist/core/dep-graph.js:16:50
      4    0.1%    0.4%  *<anonymous> dist/core/create-from-json.js:57:54
      3    0.1%    0.3%  *<anonymous> nm/lodash.constant/index.js:26:18
      2    0.0%    0.2%  *hashGet nm/lodash.has/index.js:185:17
      1    0.0%    0.1%  RegExp: ['\n\r\u2028\u2029\\]
      1    0.0%    0.1%  RegExp: <%-([\s\S]+?)%>|<%=([\s\S]+?)%>|\$\{([^\\}]*(?:\\.[^\\}]*)*)\}|<%([\s\S]+?)%>|$
      1    0.0%    0.1%  *has nm/lodash.has/index.js:1085:13
```

That regex? It's parsing the `a.b` expression in:
```
> require('lodash').has({a: {b: 5}}, 'a.b')
true
```

I'm pretty confident that we absolutely do not want that behaviour.
