### PR TITLE
chore: Add .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
This patch adds a `.npmrc` file with `package-lock=false` to prevent devs generating local lockfiles. These wouldn't be committed due to the `.gitignore`, but they will cause weird issues locally that wouldn't exist in CI