### PR TITLE
feat: test on node 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
-dist: bionic
+dist: focal
 sudo: false
 notifications:
   email: false
 language: node_js
 node_js:
+  - "16"
   - "14"
   - "12"
   - "10"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/graphlib": "^2.1.7",
-    "@types/jest": "^26.0.23",
+    "@types/jest": "^27",
     "@types/node": "^8",
     "@types/object-hash": "^2.1.0",
     "@types/semver": "^7.3.6",


### PR DESCRIPTION
#### What does this PR do?

Add support for node 16, which involves just updating a `@types` dependency, to make new `npm` happy, apparently.