### PR TITLE
feat(breaking): bump node baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^2.3.1",
     "ts-jest": "^27.0.3",
     "ts-node": "^10.0.0",
-    "typescript": "~4.3.4"
+    "typescript": "~4.6.3"
   },
   "dependencies": {
     "event-loop-spinner": "^2.1.0",
@@ -64,8 +64,8 @@
     "lodash.transform": "^4.6.0",
     "lodash.union": "^4.6.0",
     "lodash.values": "^4.3.0",
-    "object-hash": "^2.0.3",
+    "object-hash": "^3.0.0",
     "semver": "^7.0.0",
-    "tslib": "^1.13.0"
+    "tslib": "^2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "npm run build"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/graphlib": "^2.1.7",
     "@types/jest": "^27",
-    "@types/node": "^8",
+    "@types/node": "^10",
     "@types/object-hash": "^2.1.0",
     "@types/semver": "^7.3.6",
     "@typescript-eslint/eslint-plugin": "^4.28.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es2017",
+    "target": "es2018",
     "lib": [
-      "es2017"
+      "es2018"
     ],
     "allowJs": true,
     "module": "commonjs",


### PR DESCRIPTION
#### What does this PR do?

Upgrade the baseline to node 10, technically a breaking change.

Upgrade some deps which are technically breaking changes, but shouldn't matter much.

The change of the `typescript` compiler version is most likely to be a breaking change in practice, given their history of breaking mocking or access to internal packages.

This will be a new major version, just in case.

tsconfig docs: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

follows: #96 