### PR TITLE
feat: drop lodash.keys (~7% speedup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "lodash.isequal": "^4.5.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isundefined": "^3.0.1",
-    "lodash.keys": "^4.2.0",
     "lodash.map": "^4.6.0",
     "lodash.reduce": "^4.6.0",
     "lodash.size": "^4.2.0",

--- a/src/core/dep-graph.ts
+++ b/src/core/dep-graph.ts
@@ -347,9 +347,9 @@ class DepGraphImpl implements types.DepGraphInternal {
 
       const pathsFromNodeToRoot = this.pathsFromNodeToRoot(id, ancestors, opts);
 
-      pathsFromNodeToRoot.forEach((path) =>
-        allPaths.push([pkgInfo].concat(path)),
-      );
+      for (const path of pathsFromNodeToRoot) {
+        allPaths.push([pkgInfo].concat(path));
+      }
 
       if (limit && allPaths.length >= limit) {
         break;

--- a/src/graphlib/graph.ts
+++ b/src/graphlib/graph.ts
@@ -6,7 +6,6 @@ import * as _filter from 'lodash.foreach';
 import * as isEmpty from 'lodash.isempty';
 import * as isFunction from 'lodash.isfunction';
 import * as isUndefined from 'lodash.isundefined';
-import * as keys from 'lodash.keys';
 import * as reduce from 'lodash.reduce';
 import * as union from 'lodash.union';
 import * as values from 'lodash.values';
@@ -148,7 +147,7 @@ export class Graph {
   }
 
   nodes() {
-    return keys(this._nodes);
+    return Object.keys(this._nodes);
   }
 
   sources() {
@@ -223,10 +222,10 @@ export class Graph {
         });
         delete this._children[v];
       }
-      each(keys(this._in[v]), removeEdge);
+      each(Object.keys(this._in[v]), removeEdge);
       delete this._in[v];
       delete this._preds[v];
-      each(keys(this._out[v]), removeEdge);
+      each(Object.keys(this._out[v]), removeEdge);
       delete this._out[v];
       delete this._sucs[v];
       --this._nodeCount;
@@ -291,7 +290,7 @@ export class Graph {
     if (this._isCompound) {
       const children = this._children[v];
       if (children) {
-        return keys(children);
+        return Object.keys(children);
       }
     } else if (v === GRAPH_NODE) {
       return this.nodes();
@@ -303,14 +302,14 @@ export class Graph {
   predecessors(v) {
     const predsV = this._preds[v];
     if (predsV) {
-      return keys(predsV);
+      return Object.keys(predsV);
     }
   }
 
   successors(v) {
     const sucsV = this._sucs[v];
     if (sucsV) {
-      return keys(sucsV);
+      return Object.keys(sucsV);
     }
   }
 


### PR DESCRIPTION
#### What does this PR do?

Replace `lodash.keys` with `Object.keys`, which should be equivalent for regular inputs, i.e. plain JS objects.

This is a roughly 7% speedup on the committed synthetic benchmarks. This was noticed in the `#fix-event-loop` accidental profiling of this function, which is the slowest thing in prod16 right now, according to that one, very biased source.
