### PR TITLE
feat: add purl to legacy dep tree

### DIFF
--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -21,6 +21,7 @@ interface DepTreeDep {
     scope?: 'dev' | 'prod';
     pruned?: 'cyclic' | 'true';
   };
+  purl?: string;
 }
 
 /**
@@ -53,10 +54,13 @@ async function depTreeToGraph(
   depTree: DepTree,
   pkgManagerName: string,
 ): Promise<types.DepGraph> {
-  const rootPkg = {
+  const rootPkg: types.PkgInfo = {
     name: depTree.name!,
     version: depTree.version || undefined,
   };
+  if (depTree.purl) {
+    rootPkg.purl = depTree.purl;
+  }
 
   const pkgManagerInfo: types.PkgManager = {
     name: pkgManagerName,
@@ -124,6 +128,10 @@ async function buildGraph(
       name: depName,
       version: dep.version,
     };
+
+    if (dep.purl) {
+      depPkg.purl = dep.purl;
+    }
 
     const depNodeId = getNodeId(depPkg.name, depPkg.version, subtreeHash);
 

--- a/test/legacy/from-dep-tree.test.ts
+++ b/test/legacy/from-dep-tree.test.ts
@@ -260,6 +260,46 @@ describe('depTreeToGraph with funky pipes in the version', () => {
   });
 });
 
+describe('depTreeToGraph with purl', () => {
+  const depTree = {
+    name: 'oak',
+    version: '1.0',
+    purl: 'pkg:deb/oak@1.0',
+    dependencies: {
+      foo: {
+        version: 'v2.3.0',
+        purl: 'pkg:deb/foo@v2.3.0',
+      },
+      bar: {
+        version: '1',
+        purl: 'pkg:dep/bar@1',
+        dependencies: {
+          foo: {
+            version: 'v2.4.0',
+            purl: 'pkg:deb/foo@v2.4.0',
+          },
+        },
+      },
+    },
+  };
+
+  let depGraph: types.DepGraph;
+  test('create', async () => {
+    depGraph = await depGraphLib.legacy.depTreeToGraph(depTree, 'deb');
+    expect(depGraph.getPkgs()).toHaveLength(4);
+    expect(depGraph.getDepPkgs()).toHaveLength(3);
+    depGraph.getPkgs().forEach((pkg) => expect(pkg.purl).toBeDefined());
+  });
+
+  test('convert to JSON and back', async () => {
+    const graphJson = depGraph.toJSON();
+    const restoredGraph = await depGraphLib.createFromJSON(graphJson);
+
+    helpers.expectSamePkgs(restoredGraph.getPkgs(), depGraph.getPkgs());
+    helpers.expectSamePkgs(restoredGraph.getDepPkgs(), depGraph.getDepPkgs());
+  });
+});
+
 describe('depTreeToGraph cycle with root', () => {
   const depTree = {
     name: 'maple',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
This commit adds the optional purl string to the legacy dep tree as well. A previous support already added support for the dep graph, but we also need support in dep tree for it.

