### PR TITLE
fix: update validate PURL logic

### DIFF
--- a/src/core/validate-graph.ts
+++ b/src/core/validate-graph.ts
@@ -66,8 +66,12 @@ export function validatePackageURL(pkg: types.PkgInfo): void {
       // For now, make this exception only for deb to cover a support case.
       case 'deb': {
         const pkgName = pkg.name.split('/').pop();
+        // This was added to be backward compatible with the case where PURL might include the source name,
+        // it handles these combinations of PURL and package name, eg
+        // "pkg:deb/libsemanage%2Flibsemanage1@3.1-1%2Bb2?upstream=libsemanage@3.1-1" --> "libsemanage/libsemanage1"
+        // "pkg:deb/libsemanage%2Flibsemanage-common@3.1-1" --> "libsemanage/libsemanage-common"
         assert(
-          pkgName === purlPkg.name,
+          pkgName === purlPkg.name || pkg.name === purlPkg.name,
           'name and packageURL name do not match',
         );
         if (purlPkg.qualifiers?.['upstream'] && pkg.name.includes('/')) {

--- a/test/core/validate-graph.test.ts
+++ b/test/core/validate-graph.test.ts
@@ -51,6 +51,14 @@ describe('validatePackageURL', () => {
           purl: 'pkg:deb/bar@1.2.3?upstream=foo%401.2.3',
         },
       ],
+      [
+        'matches on when source name is present and purl includes source name',
+        {
+          name: 'foo/bar',
+          version: '1.2.3',
+          purl: 'pkg:deb/debian/foo%2Fbar@1.2.3',
+        },
+      ],
     ])(
       'matches only on package name for debian purls: %s',
       (_testCaseName, pkg) => {
@@ -73,14 +81,6 @@ describe('validatePackageURL', () => {
           name: 'foo/bar',
           version: '1.2.3',
           purl: 'pkg:deb/bar@1.2.3?upstream=baz',
-        },
-      ],
-      [
-        'purl includes source name',
-        {
-          name: 'foo/bar',
-          version: '1.2.3',
-          purl: 'pkg:deb/debian/foo%2Fbar@1.2.3',
         },
       ],
     ])('should throw on invalid purl: %s', (_testCaseName, pkg) => {


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Update the validate PURL logic to account for when PURL also include the source name of the package.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
