### PR TITLE
fix: validation logic of cocoapods purls

### DIFF
--- a/src/core/validate-graph.ts
+++ b/src/core/validate-graph.ts
@@ -60,6 +60,19 @@ export function validatePackageURL(pkg: types.PkgInfo): void {
         );
         break;
 
+      // CocoaPods have an optional subspec encoded in the subpath
+      // component of the purl, which – if present – should
+      // be appended to the spec.
+      case 'cocoapods':
+        assert(
+          pkg.name ===
+            (purlPkg.subpath
+              ? `${purlPkg.name}/${purlPkg.subpath}`
+              : purlPkg.name),
+          `name and packageURL name do not match`,
+        );
+        break;
+
       case 'golang': {
         let expected = purlPkg.namespace
           ? `${purlPkg.namespace}/${purlPkg.name}`

--- a/test/core/validate-graph.test.ts
+++ b/test/core/validate-graph.test.ts
@@ -88,6 +88,58 @@ describe('validatePackageURL', () => {
     });
   });
 
+  describe('cocoapods Purl type tests', () => {
+    it.each([
+      [
+        'cocoapods package without subspec',
+        {
+          name: 'bar',
+          version: '1.2.3',
+          purl: 'pkg:cocoapods/bar@1.2.3',
+        },
+      ],
+      [
+        'cocoapods package with subspec',
+        {
+          name: 'spec/subspec',
+          version: '1.2.3',
+          purl: 'pkg:cocoapods/spec@1.2.3#subspec',
+        },
+      ],
+    ])('validates cocoapods Purls: %s', (name, pkg) => {
+      expect(() => validatePackageURL(pkg)).not.toThrow();
+    });
+
+    it.each([
+      [
+        'package name does not match purl name',
+        {
+          name: 'foo',
+          version: '1.2.3',
+          purl: 'pkg:cocoapods/baz@1.2.3',
+        },
+      ],
+      [
+        'package name does not match subspec',
+        {
+          name: 'baz/foo',
+          version: '1.2.3',
+          purl: 'pkg:cocoapods/baz@1.2.3#bar',
+        },
+      ],
+      [
+        'package name does not include subspec',
+        {
+          name: 'bar',
+          version: '1.2.3',
+          purl: 'pkg:cocoapods/bar@1.2.3#baz',
+        },
+      ],
+    ])('should throw on invalid purl: %s', (name, pkg) => {
+      expect(() => validatePackageURL(pkg)).toThrow();
+    });
+  });
+
   describe('composer Purl type tests', () => {
     it.each([
       [


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This adds another case for the validation of `cocoapods` purls. CocoaPods purls encode the spec name as package name, and put the optional sub-spec on the subpath component; as opposed to the DepGraph which will encode spec name and subspec in a single, slash-divided string.

E.g.

```
// Snyk PkgInfo
{
  "name": "Adjust/Core",
  "version": "4.17.1"
}

// PackageURL
"pkg:cocoapods/Adjust@4.17.1#Core"
```

See specification for `cocoapods` purls here: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#cocoapods.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
