### PR TITLE
fix: consider purl subpath when validating golang package

### DIFF
--- a/src/core/validate-graph.ts
+++ b/src/core/validate-graph.ts
@@ -60,8 +60,16 @@ export function validatePackageURL(pkg: types.PkgInfo): void {
         );
         break;
 
+      case 'golang': {
+        let expected = purlPkg.namespace
+          ? `${purlPkg.namespace}/${purlPkg.name}`
+          : purlPkg.name;
+        if (purlPkg.subpath) expected += `/${purlPkg.subpath}`;
+        assert(pkg.name === expected, `name and packageURL name do not match`);
+        break;
+      }
+
       case 'composer':
-      case 'golang':
       case 'npm':
       case 'swift':
         assert(

--- a/test/core/validate-graph.test.ts
+++ b/test/core/validate-graph.test.ts
@@ -158,6 +158,14 @@ describe('validatePackageURL', () => {
           purl: 'pkg:golang/foo@1.2.3',
         },
       ],
+      [
+        'golang package with subpath',
+        {
+          name: 'github.com/foo/bar/pkg/baz',
+          version: '1.2.3',
+          purl: 'pkg:golang/github.com/foo/bar@1.2.3#pkg/baz',
+        },
+      ],
     ])('validates golang Purls: %s', (name, pkg) => {
       expect(() => validatePackageURL(pkg)).not.toThrow();
     });
@@ -180,11 +188,27 @@ describe('validatePackageURL', () => {
         },
       ],
       [
+        'package name does not match purl subpath',
+        {
+          name: 'bar/baz',
+          version: '1.2.3',
+          purl: 'pkg:golang/bar@1.2.3#pkg/baz',
+        },
+      ],
+      [
         'package name does not include purl namespace',
         {
           name: 'bar',
           version: '1.2.3',
           purl: 'pkg:golang/google.golang.org/bar@1.2.3',
+        },
+      ],
+      [
+        'package name does not include purl subpath',
+        {
+          name: 'bar',
+          version: '1.2.3',
+          purl: 'pkg:golang/bar@1.2.3#pkg/baz',
         },
       ],
     ])('should throw on invalid purl: %s', (name, pkg) => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This fixes the validation of a `golang` purl, which may point to a sub-package on its `subpath` component.