### PR TITLE
fix: lock down packageurl-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash.union": "^4.6.0",
     "lodash.values": "^4.3.0",
     "object-hash": "^3.0.0",
-    "packageurl-js": "^1.0.0",
+    "packageurl-js": "1.2.0",
     "semver": "^7.0.0",
     "tslib": "^2"
   }


### PR DESCRIPTION
#### What does this PR do?

Locks down `packageurl-js` to `v1.2.0`. This is the latest version that still allows percent-encuded "+" signs in purl versions.

See tread: https://snyk.slack.com/archives/C01ULJ2H4SF/p1697450545247049
