### PR TITLE
chore: switch to crypto-browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "~4.6.3"
   },
   "dependencies": {
+    "crypto-browserify": "^3.12.0",
     "event-loop-spinner": "^2.1.0",
     "lodash.clone": "^4.5.0",
     "lodash.constant": "^3.0.0",

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import * as crypto from 'crypto-browserify';
 import { eventLoopSpinner } from 'event-loop-spinner';
 
 import * as types from '../core/types';


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Switch from the node crypto library to crypto-browserify. 

#### Where should the reviewer start?
Tests pass with this change and your tests cover this code path so we should be good.

#### How should this be manually tested?


#### Any background context you want to provide?
I need to work with the backstage snyk plugin which depends on this library, and when using webpack 5 this library fails because webpack 5 doesn't provide a polyfill for crypto

```
Error: Failed to compile '../../node_modules/@snyk/dep-graph/dist/legacy/index.js':
  Module not found: Error: Can't resolve 'crypto' in '/home/adamdrew/Development/snyk-plugin-dev/node_modules/@snyk/dep-graph/dist/legacy'
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
	- install 'crypto-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "crypto": false }
```

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
