### PR TITLE
[PRODSEC-3273]: Change secrets scanning channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
-          channel: snyk-on-snyk-analysis_arch
+          channel: snyk-vuln-alerts-arch
           filters:
             branches:
               ignore:


### PR DESCRIPTION
[PRODSEC-3273]: Change secrets scanning channel from snyk-on-snyk-analysis_arch to snyk-vuln-alerts-arch

-- 
Committed by prodsec-tools-v2 using octopilot