### PR TITLE
fix: coerce node.info.labels values to strings

### DIFF
--- a/go/pkg/depgraph/depgraph.go
+++ b/go/pkg/depgraph/depgraph.go
@@ -61,7 +61,7 @@ type (
 
 	NodeInfo struct {
 		VersionProvenance *VersionProvenance `json:"versionProvenance,omitempty"`
-		Labels            map[string]string  `json:"labels,omitempty"`
+		Labels            Labels             `json:"labels,omitempty"`
 	}
 
 	Dependency struct {

--- a/go/pkg/depgraph/depgraph_labels.go
+++ b/go/pkg/depgraph/depgraph_labels.go
@@ -1,0 +1,73 @@
+package depgraph
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+type Labels map[string]string
+
+func (l *Labels) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&raw); err != nil {
+		return fmt.Errorf("could not decode labels: %w", err)
+	}
+
+	if raw == nil {
+		*l = nil
+		return nil
+	}
+
+	labels := make(Labels, len(raw))
+	for k, v := range raw {
+		s, skipLabel, err := coerceLabelValue(k, v)
+		if err != nil {
+			return err
+		}
+		if skipLabel {
+			continue
+		}
+		labels[k] = s
+	}
+	*l = labels
+	return nil
+}
+
+const (
+	keepLabel = false
+	skipLabel = true
+)
+
+func coerceLabelValue(key string, raw json.RawMessage) (string, bool, error) {
+	// encoding/json strips surrounding whitespace from RawMessage values
+	switch raw[0] {
+	case '"': // string
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return "", keepLabel, fmt.Errorf("could not decode label %q: %w", key, err)
+		}
+		return s, keepLabel, nil
+	case 't', 'f': // boolean
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return "", keepLabel, fmt.Errorf("could not decode label %q: %w", key, err)
+		}
+		if b {
+			return "true", keepLabel, nil
+		}
+		return "false", keepLabel, nil
+	case 'n': // null - omit the key entirely
+		return "", skipLabel, nil
+	case '{', '[': // object or array - unsupported
+		return "", keepLabel, fmt.Errorf("unsupported label value type for key %q", key)
+	default: // number
+		var n json.Number
+		if err := json.Unmarshal(raw, &n); err != nil {
+			return "", keepLabel, fmt.Errorf("could not decode label %q: %w", key, err)
+		}
+		return n.String(), keepLabel, nil
+	}
+}

--- a/go/pkg/depgraph/depgraph_labels_test.go
+++ b/go/pkg/depgraph/depgraph_labels_test.go
@@ -1,0 +1,130 @@
+package depgraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDepGraph_UnmarshalJSON_RealWorldExample(t *testing.T) {
+	payload := []byte(`{
+		"schemaVersion": "1.1.0",
+		"pkgManager": {"name": "cocoapods"},
+		"pkgs": [
+			{"id": "root@1.0.0", "info": {"name": "root", "version": "1.0.0"}}
+		],
+		"graph": {
+			"rootNodeId": "root-node",
+			"nodes": [
+				{
+					"nodeId": "root-node",
+					"pkgId": "root@1.0.0",
+					"deps": [],
+					"info": {
+						"labels": {
+							"externalSourceBranch": 300,
+							"normal": "value"
+						}
+					}
+				}
+			]
+		}
+	}`)
+
+	dg, err := UnmarshalJSON(payload)
+	require.NoError(t, err)
+
+	require.NotNil(t, dg.Graph.Nodes[0].Info)
+	assert.Equal(t, Labels{
+		"externalSourceBranch": "300",
+		"normal":               "value",
+	}, dg.Graph.Nodes[0].Info.Labels)
+}
+
+func TestLabels_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Labels
+		wantErr string // substring match; empty means no error
+	}{
+		// happy paths
+		{name: "empty object", input: `{}`, want: Labels{}},
+		{name: "top-level null", input: `null`, want: nil},
+		{name: "string value", input: `{"k":"v"}`, want: Labels{"k": "v"}},
+		{name: "empty string value", input: `{"k":""}`, want: Labels{"k": ""}},
+		{name: "unicode string", input: `{"k":"héllo"}`, want: Labels{"k": "héllo"}},
+		{
+			name:  "padded whitespace around values",
+			input: "{\n\t\"num\":   300  ,\n\t\"str\" :\t\"value\" ,\n\t\"bool\":\n\t\ttrue ,\n\t\"nul\" : null\n}",
+			want:  Labels{"num": "300", "str": "value", "bool": "true"},
+		},
+
+		// numeric coercion (the reported bug)
+		{name: "integer", input: `{"k":300}`, want: Labels{"k": "300"}},
+		{name: "negative integer", input: `{"k":-1}`, want: Labels{"k": "-1"}},
+		{name: "float", input: `{"k":1.5}`, want: Labels{"k": "1.5"}},
+		{name: "scientific notation", input: `{"k":1e10}`, want: Labels{"k": "1e10"}},
+		{
+			name:  "large int preserved",
+			input: `{"k":12345678901234567890}`,
+			want:  Labels{"k": "12345678901234567890"},
+		},
+
+		// bool / null
+		{name: "true", input: `{"k":true}`, want: Labels{"k": "true"}},
+		{name: "false", input: `{"k":false}`, want: Labels{"k": "false"}},
+		{name: "null value omits key", input: `{"k":null}`, want: Labels{}},
+		{
+			name:  "only null values yields empty map",
+			input: `{"a":null,"b":null}`,
+			want:  Labels{},
+		},
+
+		// mixed
+		{
+			name:  "mixed types",
+			input: `{"a":1,"b":"x","c":true,"d":null}`,
+			want:  Labels{"a": "1", "b": "x", "c": "true"},
+		},
+
+		// errors
+		{
+			name:    "object value",
+			input:   `{"k":{"x":1}}`,
+			wantErr: `unsupported label value type for key "k"`,
+		},
+		{
+			name:    "array value",
+			input:   `{"k":[1,2]}`,
+			wantErr: `unsupported label value type for key "k"`,
+		},
+		{
+			name:    "invalid json",
+			input:   `{`,
+			wantErr: "could not decode labels",
+		},
+		{
+			name:    "top-level array",
+			input:   `[1,2]`,
+			wantErr: "could not decode labels",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got Labels
+			err := got.UnmarshalJSON([]byte(tc.input))
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
#### What does this PR do?

Supports successful loading of depgraphs in Go where the `node.info.labels` values are not strings.

This change will coerce `number` and `bool` to `string` ensuring that the depgraph can be loaded without throwing an error.

- `null` values will be omitted from the label `map[string]string`
  - omitting the key, rather than keeping it as an empty string `""` seems to represents the value of `null` better, i.e. the absence of a value.
- An error will still be thrown for objects and arrays.
  - Currently an error is thrown for all values which aren't strings.

There are already depgraph snapshots in Snyk with invalid values which fail when being loaded through this go module. For instance Cocoapods depgraphs where `AFNetworkActivityLogger` was pinned to branch `3_0_0`. See [fix PR](https://github.com/snyk/cocoapods-lockfile-parser/pull/50) for more details. Which results in

```json
					"info": {
						"labels": {
							"externalSourceBranch": 300,
							"normal": "value"
						}
					}
```
