### PR TITLE
chore: [PRODSEC-10309] Update CODEOWNERS to remove analysis-arch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/analysis-arch @snyk/codesec_arch
+@snyk/codesec_arch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@snyk/codesec_arch
+* @snyk/codesec_arch


### PR DESCRIPTION
Removed the `analysis-arch` owner from CODEOWNERS. IaC derived `codesec_arch` will be the only team in CODEOWNERS (https://github.com/snyk/github-governance-manifests/blob/main/snyk/project-teams/codesec_arch.yml).
