### PR TITLE
fix: include root node in Go ContentHash to match TS equals func

### DIFF
--- a/go/pkg/depgraph/content_hash_test.go
+++ b/go/pkg/depgraph/content_hash_test.go
@@ -36,6 +36,10 @@ var (
 	contentHashCyclesOneNodeA []byte
 	//go:embed testdata/equals/cycles/one-node-cycle-b.json
 	contentHashCyclesOneNodeB []byte
+	//go:embed testdata/equals/pnpm-root-version-a.json
+	contentHashPnpmRootVersionA []byte
+	//go:embed testdata/equals/pnpm-root-version-b.json
+	contentHashPnpmRootVersionB []byte
 )
 
 func mustParseContentHash(t *testing.T, data []byte) *DepGraph {
@@ -47,17 +51,40 @@ func mustParseContentHash(t *testing.T, data []byte) *DepGraph {
 
 // --- ContentHash tests ---
 
-func TestContentHash_StructurallySameGraphs_SameHash(t *testing.T) {
-	// Same dependency structure, different root pkg version (simple vs simple-different-root)
-	a := mustParseContentHash(t, contentHashSimple)
-	b := mustParseContentHash(t, contentHashSimpleDifferentRoot)
+// TestContentHash_RootDiffers_DifferentHash pins the contract that the root node
+// is part of the content hash. Mirrors the TS DepGraph.equals() default
+// (compareRoot=true): two graphs whose only difference is the root pkg must
+// hash differently. Each subtest exercises a different fixture shape.
+func TestContentHash_RootDiffers_DifferentHash(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []byte
+	}{
+		{
+			name: "pnpm root-only graph",
+			a:    contentHashPnpmRootVersionA,
+			b:    contentHashPnpmRootVersionB,
+		},
+		{
+			name: "maven graph with deps",
+			a:    contentHashSimple,
+			b:    contentHashSimpleDifferentRoot,
+		},
+	}
 
-	hashA := a.ContentHash()
-	hashB := b.ContentHash()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := mustParseContentHash(t, tc.a)
+			b := mustParseContentHash(t, tc.b)
 
-	require.NotNil(t, hashA)
-	require.NotNil(t, hashB)
-	assert.Equal(t, hashA, hashB, "structurally same graphs must produce same content hash")
+			hashA := a.ContentHash()
+			hashB := b.ContentHash()
+
+			require.NotNil(t, hashA)
+			require.NotNil(t, hashB)
+			assert.NotEqual(t, hashA, hashB, "graphs differing only in the root node must have different hashes")
+		})
+	}
 }
 
 func TestContentHash_SameGraphDifferentNodeIDs_SameHash(t *testing.T) {

--- a/go/pkg/depgraph/depgraph.go
+++ b/go/pkg/depgraph/depgraph.go
@@ -275,7 +275,9 @@ func (dg *DepGraph) validateRootNotReferenced() error {
 }
 
 // ContentHash returns a deterministic hash of the graph structure for content-addressing.
-// Structurally equivalent graphs (same deps, PkgInfo, NodeInfo; root package may differ) must produce the same hash.
+// Structurally equivalent graphs (same root, deps, PkgInfo, NodeInfo) produce the same hash;
+// any difference, including in the root node, produces a different hash. This mirrors the
+// @snyk/dep-graph TypeScript DepGraph.equals() default (compareRoot=true).
 // If BuildGraph hasn't been called already on the DepGraph, this function will invoke the method first.
 func (dg *DepGraph) ContentHash() []byte {
 	if dg.pkgIdx == nil || dg.nodeIdx == nil {
@@ -317,8 +319,9 @@ func (dg *DepGraph) hashGraphRecursively(node *Node, visited map[*Node]struct{},
 	visited[node] = struct{}{}
 	defer func() { delete(visited, node) }()
 
-	if node.pkg != nil && node != dg.rootNode {
-		// PkgInfo: name, version, purl (canonical order)
+	if node.pkg != nil {
+		// PkgInfo: name, version, purl (canonical order). The root node is included
+		// to match the TS DepGraph.equals() default (compareRoot=true).
 		w.WriteString("pkg:")
 		w.WriteString(node.pkg.Info.Name)
 		w.WriteByte(0)

--- a/go/pkg/depgraph/testdata/equals/pnpm-root-version-a.json
+++ b/go/pkg/depgraph/testdata/equals/pnpm-root-version-a.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@openclaw/microsoft-foundry@2026.5.24",
+      "info": {
+        "name": "@openclaw/microsoft-foundry",
+        "version": "2026.5.24"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@openclaw/microsoft-foundry@2026.5.24",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/go/pkg/depgraph/testdata/equals/pnpm-root-version-b.json
+++ b/go/pkg/depgraph/testdata/equals/pnpm-root-version-b.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@openclaw/microsoft-foundry@2026.5.26",
+      "info": {
+        "name": "@openclaw/microsoft-foundry",
+        "version": "2026.5.26"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@openclaw/microsoft-foundry@2026.5.26",
+        "deps": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The Go `DepGraph.ContentHash()` previously skipped the root node when hashing, while the TS `DepGraph.equals()` default (`compareRoot=true`) treats the root as part of "content". 

This pull request align Go to TS by dropping the `node != dg.rootNode` guard in `hashGraphRecursively`. 

**BREAKING CHANGE**: `ContentHash` output changes for every dep-graph, not only ones whose root differs across runs. The hashed buffer now starts with the root's PkgInfo/NodeInfo bytes, so SHA-256 produces a new value for any input — even byte-identical content that previously hashed to a stable value will hash to a different value under this version.