### PR TITLE
fix: run TS and Go tests on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,13 +91,9 @@ workflows:
 
       - test_ts:
           name: Test TS code
-          requires:
-            - Scan repository for secrets
 
       - test_go:
           name: Test Go code
-          requires:
-            - Scan repository for secrets
 
       - release:
           name: Release


### PR DESCRIPTION
The test_ts and test_go jobs required the secrets-scan job, which is filtered to ignore master. CircleCI skips dependents of filtered-out jobs, so neither test suite ran on master pushes.
