### PR TITLE
fix(ci): run tests and secrets scan on all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,10 +81,6 @@ workflows:
           context:
             - snyk-bot-slack
           channel: snyk-vuln-alerts-arch
-          filters:
-            branches:
-              ignore:
-                - master
 
       - security-scans:
           name: Security Scans
@@ -93,13 +89,9 @@ workflows:
 
       - test_ts:
           name: Test TS code
-          requires:
-            - Scan repository for secrets
 
       - test_go:
           name: Test Go code
-          requires:
-            - Scan repository for secrets
 
       - release:
           name: Release


### PR DESCRIPTION
test_ts/test_go only required the secrets scan, which is skipped on
master, so they (and the release that depends on them) never ran on
master. Drop the requires so tests run on every branch, and run the
secrets scan on master too.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
