### PR TITLE
fix(depgraph): avoid exponential blowup in ContentHash for stacked-diamond DAGs

### DIFF
--- a/go/pkg/depgraph/content_hash_test.go
+++ b/go/pkg/depgraph/content_hash_test.go
@@ -1,7 +1,9 @@
 package depgraph
 
 import (
+	"crypto/sha256"
 	_ "embed"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -171,4 +173,58 @@ func TestContentHash_OneNodeCycleVsNoCycle_DifferentHash(t *testing.T) {
 	b := mustParseContentHash(t, contentHashCyclesOneNodeB)
 
 	assert.NotEqual(t, a.ContentHash(), b.ContentHash(), "graph with self-loop vs graph without cycle must have different hashes")
+}
+
+func TestContentHash_DiamondChain(t *testing.T) {
+	diamonds := 20
+	dg := buildDiamondChain(t, diamonds)
+
+	require.Equalf(t, 3*diamonds+1, len(dg.Graph.Nodes), "node count must be linear in n (n=%d)", diamonds)
+
+	digest := dg.ContentHash()
+	require.Lenf(t, digest, sha256.Size,
+		"ContentHash must return a %d-byte digest for a %d-diamond chain (2^%d paths)", sha256.Size, diamonds, diamonds)
+
+	assert.Equalf(t, digest, dg.ContentHash(), "ContentHash must be deterministic (n=%d)", diamonds)
+}
+
+func buildDiamondChain(t *testing.T, n int) *DepGraph {
+	t.Helper()
+	dg := New()
+	dg.SchemaVersion = "1.3.0"
+	dg.PkgManager = PkgManager{Name: "test"}
+
+	addPkg := func(id string) {
+		dg.Pkgs = append(dg.Pkgs, Pkg{ID: id, Info: PkgInfo{Name: id, Version: "1.0.0"}})
+	}
+	addNode := func(nodeID, pkgID string, deps ...string) {
+		d := make([]Dependency, len(deps))
+		for i, x := range deps {
+			d[i] = Dependency{NodeID: x}
+		}
+		dg.Graph.Nodes = append(dg.Graph.Nodes, Node{NodeID: nodeID, PkgID: pkgID, Deps: d})
+	}
+	mergePkg := func(i int) string {
+		if i == 0 {
+			return "root"
+		}
+		return fmt.Sprintf("m%d", i)
+	}
+
+	dg.Graph.RootNodeID = "m0"
+	addPkg("root")
+	for i := 0; i < n; i++ {
+		addPkg(fmt.Sprintf("a%d", i))
+		addPkg(fmt.Sprintf("b%d", i))
+		addPkg(fmt.Sprintf("m%d", i+1))
+	}
+
+	for i := 0; i < n; i++ {
+		addNode(fmt.Sprintf("m%d", i), mergePkg(i), fmt.Sprintf("a%d", i), fmt.Sprintf("b%d", i))
+		addNode(fmt.Sprintf("a%d", i), fmt.Sprintf("a%d", i), fmt.Sprintf("m%d", i+1))
+		addNode(fmt.Sprintf("b%d", i), fmt.Sprintf("b%d", i), fmt.Sprintf("m%d", i+1))
+	}
+	addNode(fmt.Sprintf("m%d", n), mergePkg(n)) // leaf
+
+	return dg
 }

--- a/go/pkg/depgraph/depgraph.go
+++ b/go/pkg/depgraph/depgraph.go
@@ -274,11 +274,6 @@ func (dg *DepGraph) validateRootNotReferenced() error {
 	return nil
 }
 
-// ContentHash returns a deterministic hash of the graph structure for content-addressing.
-// Structurally equivalent graphs (same root, deps, PkgInfo, NodeInfo) produce the same hash;
-// any difference, including in the root node, produces a different hash. This mirrors the
-// @snyk/dep-graph TypeScript DepGraph.equals() default (compareRoot=true).
-// If BuildGraph hasn't been called already on the DepGraph, this function will invoke the method first.
 func (dg *DepGraph) ContentHash() []byte {
 	if dg.pkgIdx == nil || dg.nodeIdx == nil {
 		if err := dg.BuildGraph(); err != nil {
@@ -287,14 +282,13 @@ func (dg *DepGraph) ContentHash() []byte {
 	}
 	if dg.rootNode == nil {
 		// Empty or invalid graph: still return a deterministic hash
-		h := sha256.Sum256([]byte("depgraph:empty"))
-		return h[:]
+		hash := sha256.Sum256([]byte("depgraph:empty"))
+		return hash[:]
 	}
-	visited := make(map[*Node]struct{})
-	w := &bytes.Buffer{}
-	dg.hashGraphRecursively(dg.rootNode, visited, w)
-	sum := sha256.Sum256(w.Bytes())
-	return sum[:]
+
+	digest, _ := dg.hashGraphRecursively(dg.rootNode, make(map[*Node]int), make(map[*Node][]byte))
+	hash := sha256.Sum256(digest)
+	return hash[:]
 }
 
 // getPkgIDFromPkg returns a canonical package id (name@version) for sorting and hashing.
@@ -305,67 +299,99 @@ func getPkgIDFromPkg(pkg *Pkg) string {
 	return getPkgIDFromPkgInfo(&pkg.Info)
 }
 
-func (dg *DepGraph) hashGraphRecursively(node *Node, visited map[*Node]struct{}, w *bytes.Buffer) {
-	if node == nil {
-		return
+func (dg *DepGraph) hashGraphRecursively(node *Node, path map[*Node]int, memo map[*Node][]byte) ([]byte, int) {
+	depth := len(path)
+	if cached, ok := memo[node]; ok {
+		return cached, depth
 	}
-	if _, ok := visited[node]; ok {
-		// Cycle: write deterministic marker (pkgId only, no nodeId)
-		w.WriteString("cycle:")
-		w.WriteString(getPkgIDFromPkg(node.pkg))
-		w.WriteByte(0)
-		return
-	}
-	visited[node] = struct{}{}
-	defer func() { delete(visited, node) }()
 
-	if node.pkg != nil {
-		// PkgInfo: name, version, purl (canonical order). The root node is included
-		// to match the TS DepGraph.equals() default (compareRoot=true).
-		w.WriteString("pkg:")
-		w.WriteString(node.pkg.Info.Name)
-		w.WriteByte(0)
-		w.WriteString(node.pkg.Info.Version)
-		w.WriteByte(0)
-		w.WriteString(node.pkg.Info.PackageURL)
-		w.WriteByte(0)
-		// NodeInfo
-		if node.Info != nil {
-			w.WriteString("info:")
-			if node.Info.VersionProvenance != nil {
-				w.WriteString(node.Info.VersionProvenance.Type)
-				w.WriteByte(0)
-				w.WriteString(node.Info.VersionProvenance.Location)
-				w.WriteByte(0)
-				if node.Info.VersionProvenance.Property != nil {
-					w.WriteString(node.Info.VersionProvenance.Property.Name)
-				}
-				w.WriteByte(0)
-			}
-			if len(node.Info.Labels) > 0 {
-				keys := make([]string, 0, len(node.Info.Labels))
-				for k := range node.Info.Labels {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
-				for _, k := range keys {
-					w.WriteString(k)
-					w.WriteByte(0)
-					w.WriteString(node.Info.Labels[k])
-					w.WriteByte(0)
-				}
-			}
+	path[node] = depth
+	defer delete(path, node)
+
+	buf := &bytes.Buffer{}
+	writeNodeFields(node, buf)
+
+	minDepthFromCurrentNode := depth
+	currentNodeParticipatesInCycle := false
+	for _, dep := range sortDepsByPkgID(node.deps) {
+		childBytes, minDepthFromChild := dg.childDigest(dep, path, memo)
+		buf.Write(childBytes)
+		if minDepthFromChild < minDepthFromCurrentNode {
+			minDepthFromCurrentNode = minDepthFromChild
+			currentNodeParticipatesInCycle = true
 		}
 	}
 
-	// Sort deps by getPkgId (match TS) then recurse
-	deps := make([]*Node, len(node.deps))
-	copy(deps, node.deps)
-	sort.Slice(deps, func(i, j int) bool {
-		pi, pj := getPkgIDFromPkg(deps[i].pkg), getPkgIDFromPkg(deps[j].pkg)
-		return pi < pj
+	sum := sha256.Sum256(buf.Bytes())
+	digest := sum[:]
+	if currentNodeParticipatesInCycle {
+		return digest, minDepthFromCurrentNode
+	}
+	memo[node] = digest
+	return digest, minDepthFromCurrentNode
+}
+
+func sortDepsByPkgID(deps []*Node) []*Node {
+	sorted := make([]*Node, len(deps))
+	copy(sorted, deps)
+	sort.Slice(sorted, func(i, j int) bool {
+		return getPkgIDFromPkg(sorted[i].pkg) < getPkgIDFromPkg(sorted[j].pkg)
 	})
-	for _, dep := range deps {
-		dg.hashGraphRecursively(dep, visited, w)
+	return sorted
+}
+
+func (dg *DepGraph) childDigest(dep *Node, path map[*Node]int, memo map[*Node][]byte) ([]byte, int) {
+	if d, ok := path[dep]; ok {
+		return cycleMarker(dep), d
+	}
+	return dg.hashGraphRecursively(dep, path, memo)
+}
+
+func cycleMarker(dep *Node) []byte {
+	buf := &bytes.Buffer{}
+	buf.WriteString("cycle:")
+	buf.WriteString(getPkgIDFromPkg(dep.pkg))
+	buf.WriteByte(0)
+	return buf.Bytes()
+}
+
+func writeNodeFields(node *Node, w *bytes.Buffer) {
+	if node.pkg == nil {
+		return
+	}
+	// PkgInfo: name, version, purl (canonical order).
+	w.WriteString("pkg:")
+	w.WriteString(node.pkg.Info.Name)
+	w.WriteByte(0)
+	w.WriteString(node.pkg.Info.Version)
+	w.WriteByte(0)
+	w.WriteString(node.pkg.Info.PackageURL)
+	w.WriteByte(0)
+	// NodeInfo
+	if node.Info != nil {
+		w.WriteString("info:")
+		if node.Info.VersionProvenance != nil {
+			w.WriteString(node.Info.VersionProvenance.Type)
+			w.WriteByte(0)
+			w.WriteString(node.Info.VersionProvenance.Location)
+			w.WriteByte(0)
+			if node.Info.VersionProvenance.Property != nil {
+				w.WriteString(node.Info.VersionProvenance.Property.Name)
+			}
+			w.WriteByte(0)
+		}
+		if len(node.Info.Labels) > 0 {
+			keys := make([]string, 0, len(node.Info.Labels))
+			for k := range node.Info.Labels {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				w.WriteString(k)
+				w.WriteByte(0)
+				w.WriteString(node.Info.Labels[k])
+				w.WriteByte(0)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## What

`DepGraph.ContentHash()` fingerprints a graph so structurally-equal graphs hash the same (mirroring the TS `DepGraph.equals()` default, `compareRoot=true`).

The previous walk used a **path-scoped** visited set (marked on entry, unmarked on exit). That correctly detects cycles, but it also re-serializes any node reachable by multiple non-cyclic paths **once per path**. For a chain of `n` stacked diamonds — only `3n+1` nodes but `2^n` distinct root→leaf paths — hashing was **O(2^n)** in time and memory.

## How

Reimplemented the walk as a **Merkle / hash-consed** hash:

- Each node's sub-graph reduces to a fixed 32-byte `sha256` digest: `subHash(node) = sha256(nodeFields ∥ ordered child digests)`.
- A node's digest is **memoised and reused** when its sub-graph is self-contained (no back-edge escapes above it), so shared sub-graphs are hashed once. Pure DAGs collapse to **O(V+E)**.
- Cycles stay path-accurate via a Tarjan low-link check (`minReach`): only sub-graphs whose cycles are fully contained get cached; anything with an upward-escaping back-edge is recomputed and still emits the original `cycle:<pkgId>` marker.

Refactored the previous monolithic `hashGraphRecursively` into focused helpers — `sortDepsByPkgID`, `childDigest`, `cycleMarker`, and `writeNodeFields` — and changed the recursion signature to thread a DFS `path` (node→depth) map and a `memo` (node→digest) cache instead of the old `visited` set and shared `*bytes.Buffer`.

## Behaviour / compatibility

- **Same equivalence classes**: equal graphs still hash equal, any structural difference (incl. root and cycles) still hashes differently. Validated against the shared `test/fixtures/equals/` corpus.
- **Absolute hash bytes change** (collapsing shared subtrees is what breaks the exponential — it necessarily alters the output). Safe here: `ContentHash` has no callers outside the package and nothing persists it in this repo. ⚠️ Before relying on this, confirm no downstream service stores these hashes as cache keys; if so, coordinate a cache/version bump.

## Tests

- All existing equal/not-equal + cycle contract tests pass unchanged.
- Added `TestContentHash_DiamondChain` (with a `buildDiamondChain` helper) that constructs a chain of 20 stacked diamonds — `3n+1` nodes but `2^20` (~1M) root→leaf paths. It asserts the node count is linear in `n`, that `ContentHash` returns a 32-byte `sha256` digest, and that the result is deterministic. Under the old path-scoped walk this input blew up exponentially; it now completes trivially.

## Known limitation (unchanged, not addressed here)

Sibling deps that share a `name@version` but have different subtrees are sorted by pkg-id only (unstable), a fragility shared with the TS `equals()`. Could be hardened later with a secondary sort on the child digest.
